### PR TITLE
fix: add api calls to dynamically rendered content

### DIFF
--- a/src/pages/about-us/index.astro
+++ b/src/pages/about-us/index.astro
@@ -4,16 +4,24 @@ import { getEntry } from "astro:content";
 import "../../index.scss";
 import Layout from "../../layouts/Layout.astro";
 import RichText from "@/components/RichText.astro";
+import payloadFetch from "@/utilities/payload-fetch";
+import type { CollectionEntry } from "astro:content";
 
-const {
-  data: { subtitle, content },
-} = await getEntry("aboutUs", "main");
+const collectionName = "aboutUs";
+let data: CollectionEntry<typeof collectionName>["data"];
+
+if (!Astro.isPrerendered) {
+  const response = await payloadFetch("globals/about-us");
+  data = await response.json();
+} else {
+  ({ data } = await getEntry(collectionName, "main"));
+}
 ---
 
 <Layout>
   <div class="grid-container">
     <h1>About us</h1>
-    {subtitle && <h2 set:text={subtitle} />}
-    <RichText content={content} />
+    {data.subtitle && <h2 set:text={data.subtitle} />}
+    <RichText content={data.content} />
   </div>
 </Layout>

--- a/src/pages/events/[slug].astro
+++ b/src/pages/events/[slug].astro
@@ -1,6 +1,7 @@
 ---
-import { getEntry, type CollectionEntry } from "astro:content";
+import { type CollectionEntry } from "astro:content";
 import { createGetStaticPath } from "@/utilities/staticPath";
+import payloadFetch from "@/utilities/payload-fetch";
 import "../../index.scss";
 import Layout from "../../layouts/Layout.astro";
 
@@ -13,12 +14,15 @@ const { slug } = Astro.params;
 // to this file
 // 3. data needs to be a top-level variable here
 const collectionName = "events";
-let data: CollectionEntry<"events">["data"];
+let data: CollectionEntry<typeof collectionName>["data"];
 
 if (!Astro.isPrerendered) {
-  const event = await getEntry(collectionName, slug);
-  if (!event) return Astro.redirect("/404");
-  ({ data } = event);
+  const response = await payloadFetch(
+    `${collectionName}?where[slug][equals]=${slug}&draft=true`
+  );
+  const events = await response.json();
+  if (events.docs.length === 0) return Astro.redirect("/404");
+  data = events.docs[0];
 } else {
   // @ts-expect-error
   ({ data } = Astro.props);
@@ -32,7 +36,7 @@ export const getStaticPaths = createGetStaticPath("events");
     <h1 set:text={data.title} />
     <p set:text={data.format} />
     <p set:text={data.location} />
-    <p set:text={data.registrationUrl} />
+    <a class="usa-button" href={data.registrationUrl}> Register </a>
     <p set:text={data.startDate} />
     <p set:text={data.endDate} />
     <section class="usa-prose" set:text={data.description} />

--- a/src/pages/events/index.astro
+++ b/src/pages/events/index.astro
@@ -3,8 +3,20 @@ import { getCollection } from "astro:content";
 import "../../index.scss";
 import Layout from "@/layouts/Layout.astro";
 import Link from "@/components/Link.astro";
+import payloadFetch from "@/utilities/payload-fetch";
+import type { CollectionEntry } from "astro:content";
 
-const events = await getCollection("events");
+const collectionName = "events";
+let events: CollectionEntry<typeof collectionName>["data"][];
+
+if (!Astro.isPrerendered) {
+  const response = await payloadFetch(`${collectionName}?draft=true`);
+  const eventsData = await response.json();
+  events = eventsData.docs;
+} else {
+  const eventCollection = await getCollection(collectionName);
+  events = eventCollection.map((event) => event.data);
+}
 ---
 
 <Layout>
@@ -14,7 +26,7 @@ const events = await getCollection("events");
       {
         events.map((event) => (
           <li>
-            <Link href={`/events/${event.data.slug}`}>{event.data.title}</Link>
+            <Link href={`/events/${event.slug}`}>{event.title}</Link>
           </li>
         ))
       }

--- a/src/pages/news/[slug].astro
+++ b/src/pages/news/[slug].astro
@@ -1,17 +1,22 @@
 ---
-import { getEntry, type CollectionEntry } from "astro:content";
+import { type CollectionEntry } from "astro:content";
 import "../../index.scss";
 import Layout from "../../layouts/Layout.astro";
 import { createGetStaticPath } from "@/utilities/staticPath";
 import RichText from "@/components/RichText.astro";
+import payloadFetch from "@/utilities/payload-fetch";
 
 const { slug } = Astro.params;
-let data: CollectionEntry<"news">["data"];
+const collectionName = "news";
+let data: CollectionEntry<typeof collectionName>["data"];
 
 if (!Astro.isPrerendered) {
-  const n = await getEntry("news", slug);
-  if (!n) return Astro.redirect("/404");
-  ({ data } = n);
+  const response = await payloadFetch(
+    `${collectionName}?where[slug][equals]=${slug}&draft=true`
+  );
+  const n = await response.json();
+  if (n.docs.length === 0) return Astro.redirect("/404");
+  data = n.docs[0];
 } else {
   ({ data } = Astro.props);
 }

--- a/src/pages/news/index.astro
+++ b/src/pages/news/index.astro
@@ -3,7 +3,20 @@ import { getCollection } from "astro:content";
 import "../../index.scss";
 import Layout from "@/layouts/Layout.astro";
 import Link from "@/components/Link.astro";
-const news = await getCollection("news");
+import type { CollectionEntry } from "astro:content";
+import payloadFetch from "@/utilities/payload-fetch";
+
+const collectionName = "news";
+let news: CollectionEntry<typeof collectionName>["data"][];
+
+if (!Astro.isPrerendered) {
+  const response = await payloadFetch(`${collectionName}?draft=true`);
+  const newsData = await response.json();
+  news = newsData.docs;
+} else {
+  const newsCollection = await getCollection(collectionName);
+  news = newsCollection.map((n) => n.data);
+}
 ---
 
 <Layout>
@@ -13,7 +26,7 @@ const news = await getCollection("news");
       {
         news.map((n) => (
           <li>
-            <Link href={`/news/${n.data.slug}`}>{n.data.title}</Link>
+            <Link href={`/news/${n.slug}`}>{n.title}</Link>
           </li>
         ))
       }


### PR DESCRIPTION
## Changes proposed in this pull request:

- Astro collections are all fetched a build time
- We can map our api responses to the same collection schema (dangerously because the `response.json` type is `any`) to create a similar effect but it should update at the time of request.

## Security considerations
Runtime data fetching (but only for the live previewer)