### PR TITLE
fix: CI preview launch bucket prefix

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -31,6 +31,7 @@ jobs:
       - get: src
         params:
           depth: 1
+        passed: [set-pipeline]
       - get: s3
         trigger: true
       - get: general-task
@@ -75,6 +76,7 @@ resources:
     source:
       access_key_id: ((editor-site-data-access-key-id-((deploy-env))))
       secret_access_key: ((editor-site-data-secret-access-key-((deploy-env))))
+      path: _sites/
       bucket: ((editor-site-data-bucket-((deploy-env))))
       region: us-gov-west-1
 


### PR DESCRIPTION
## Changes proposed in this pull request:

- Updates the CI S3 resource to use the `_sites` prefix in the S3 bucket.

## Security considerations

N/A
