### PR TITLE
chore: Set security considerations action to read only

### DIFF
--- a/.github/workflows/security-considerations.yml
+++ b/.github/workflows/security-considerations.yml
@@ -1,5 +1,8 @@
 name: Security Considerations Workflow
 
+permissions:
+  pull-requests: read
+
 on:
   pull_request:
     types: [opened, edited, reopened]


### PR DESCRIPTION
## Changes proposed in this pull request:
- Makes security considerations permissions read only.

## security considerations
Makes perms read only