### PR TITLE
Feat update events page styling

### DIFF
--- a/src/components/CollectionItem.astro
+++ b/src/components/CollectionItem.astro
@@ -2,36 +2,61 @@
 import Link from "@/components/Link.astro";
 import SectionHeader from "@/components/SectionHeader.astro";
 import Tags, { type Tag } from "@/components/Tags.astro";
+import { parseDateParts, type DateParts } from "@/utilities/dates";
 
 export interface Props {
   title: string;
   description?: string;
-  date?: string;
+  date?: string | DateParts;
+  startDate?: string | DateParts;
+  endDate?: string | DateParts;
   tags?: Tag[];
   image?: string;
   imageAlt?: string;
   link?: string;
   linkText?: string;
+  showEvent?: boolean;
 }
 
 const {
   title = "", 
   description = "", 
-  date = "", 
+  date = "",
+  startDate = "",
   tags = [],
   image = "", 
   imageAlt = "", 
   link = "",
+  showEvent = false,
 } = Astro.props;
 
+function normalizeDate(input?: string | DateParts): DateParts | null {
+  return input
+    ? (typeof input === 'string' ? parseDateParts(input) : input)
+    : null; 
+}
+
+const dateParts = normalizeDate(date);
+const startParts = normalizeDate(startDate);
+
 const hasTags = tags?.length > 0; 
-const hasDescription = !!description?.trim(); 
+const hasDescription = !!description?.trim();
+
+const hasValidDate = !!(dateParts && dateParts.raw instanceof Date && !isNaN(dateParts.raw.getTime()));
 ---
 
 <>
   <li class="usa-collection__item">
     {image && (
       <img class="usa-collection__img" src={image} alt={imageAlt} />
+    )}
+    {showEvent && startParts?.raw && (
+      <div class="usa-collection__calendar-date">
+      <time datetime={startParts.raw.toISOString()}>
+        <span class="usa-collection__calendar-date-month">{startParts.abbrMonth}</span>
+        <span class="usa-collection__calendar-date-day">{startParts.day}</span>
+      </time>
+    </div>
     )}
     <div class="usa-collection__body">
       <SectionHeader headingLevel="h2" class="usa-collection__heading font-body-lg">
@@ -42,8 +67,15 @@ const hasDescription = !!description?.trim();
           <p>{description}</p>
         </div>
       )}
+      {hasValidDate && !showEvent &&(
+        <ul class="usa-collection__meta" aria-label="More information">
+          <li class="usa-collection__meta-item">
+            <time datetime={dateParts.raw.toISOString()}>{dateParts.full}</time>
+          </li>
+        </ul>
+      )}
       {hasTags && (
-        <ul class="usa-collection__meta display-flex margin-top-2" aria-label="More information">
+        <ul class="usa-collection__meta display-flex margin-top-2" aria-label="Tag links">
           <Tags tags={tags} />
         </ul>
       )}

--- a/src/components/CollectionItem.test.ts
+++ b/src/components/CollectionItem.test.ts
@@ -76,7 +76,7 @@ describe('CollectionItem', () => {
     });
 
     expect(html).toContain('usa-collection__meta');
-    expect(html).toContain('More information'); // aria-label text
+    expect(html).toContain('Tag links'); // aria-label text
     expect(html).toContain('News');
     expect(html).toContain('UX');
   });
@@ -101,4 +101,30 @@ describe('CollectionItem', () => {
     expect(html).toContain('href="/bare"');
     expect(html).not.toContain('<img');
   });
+
+  it('renders event date when showEvent and startDate are provided', async () => {
+    const html = await renderHTML({
+      title: 'Event test',
+      link: '/event',
+      showEvent: true,
+      startDate: '2024-12-25',
+    });
+
+    expect(html).toContain('Event test');
+    expect(html).toContain('href="/event"');
+    expect(html).toContain('Dec');
+  });
+
+  it('does not render event date when startDate is missing', async () => {
+    const html = await renderHTML({
+      title: 'Event without Start',
+      link: '/event-no-date',
+      showEvent: true,
+    });
+
+    expect(html).not.toContain('usa-collection__calendar-date');
+    expect(html).not.toContain('<time');
+  });
+
+
 });

--- a/src/components/CollectionItemList.astro
+++ b/src/components/CollectionItemList.astro
@@ -1,7 +1,7 @@
 ---
 import CollectionItem from "@/components/CollectionItem.astro";
 
-const { items = [] } = Astro.props;
+const { items = [], showEvent = false } = Astro.props;
 ---
 
 <>
@@ -10,7 +10,7 @@ const { items = [] } = Astro.props;
     items.length > 0 && (
       <ol class="usa-collection-group measure-6">
         {items.map((n) => (
-         <CollectionItem {...n} /> 
+         <CollectionItem {...n} showEvent={showEvent}/> 
         ))}
       </ol>
     )

--- a/src/pages/events/[slug].astro
+++ b/src/pages/events/[slug].astro
@@ -2,7 +2,9 @@
 import { type CollectionEntry } from "astro:content";
 import { createGetStaticPath } from "@/utilities/staticPath";
 import payloadFetch from "@/utilities/payload-fetch";
-import Layout from "../../layouts/Layout.astro";
+import { tryParseDateParts } from "@/utilities/dates";
+import PagesSection from "@/components/PagesSection.astro";
+import Layout from "@/layouts/Layout.astro";
 
 const { slug } = Astro.params;
 
@@ -27,17 +29,42 @@ if (!Astro.isPrerendered) {
   ({ data } = Astro.props);
 }
 
+const start = tryParseDateParts(data.startDate);
+const end = tryParseDateParts(data.endDate);
+
 export const getStaticPaths = createGetStaticPath("events");
 ---
 
-<Layout title={data.title}>
-  <article class="grid-container">
-    <h1 set:text={data.title} />
-    <p set:text={data.format} />
-    <p set:text={data.location} />
-    <a class="usa-button" href={data.registrationUrl}> Register </a>
-    <p set:text={data.startDate} />
-    <p set:text={data.endDate} />
-    <section class="usa-prose" set:text={data.description} />
-  </article>
+<Layout title="events">
+  <PagesSection heading={data.title}>
+    <div
+      class="usa-summary-box margin-bottom-2"
+      role="region"
+      aria-labelledby={`event-details-${slug}`}
+    >
+    <div class="usa-summary-box__body">
+      <h2 class="usa-summary-box__heading" id={`event-details-${slug}`}>
+        Event details
+      </h2>
+      <div class="usa-summary-box__text">
+        <ul class="usa-list">
+          <li><b>Format:</b> {data.format}</li>
+          <li><b>Location:</b> {data.location}</li>
+          <li>
+            <b>Date and time:</b> {start.full}
+            {end && (
+              <span>until {end!.full}</span>
+            )}
+          </li>
+        </ul>
+      </div>
+    </div>
+    </div>
+    <section>
+      {data.description && 
+        <p class="margin-bottom-2">{data.description}</p>
+      }
+      <a class="usa-button" href={data.registrationUrl}>Register</a>
+    </section>
+  </PagesSection>
 </Layout>

--- a/src/pages/events/index.astro
+++ b/src/pages/events/index.astro
@@ -1,9 +1,11 @@
 ---
 import { getCollection } from "astro:content";
 import Layout from "@/layouts/Layout.astro";
-import Link from "@/components/Link.astro";
-import payloadFetch from "@/utilities/payload-fetch";
+import CollectionItemList from "@/components/CollectionItemList.astro";
+import PagesSection from "@/components/PagesSection.astro";
 import type { CollectionEntry } from "astro:content";
+import payloadFetch from "@/utilities/payload-fetch";
+import { eventsMapper } from "@/utilities/eventsMapper";
 
 const collectionName = "events";
 let events: CollectionEntry<typeof collectionName>["data"][];
@@ -13,22 +15,15 @@ if (!Astro.isPrerendered) {
   const eventsData = await response.json();
   events = eventsData.docs;
 } else {
-  const eventCollection = await getCollection(collectionName);
-  events = eventCollection.map((event) => event.data);
+  const eventsCollection = await getCollection(collectionName);
+  events = eventsCollection.map((n) => n.data);
 }
+
+const items = events.map(eventsMapper);
 ---
 
-<Layout>
-  <div class="grid-container">
-    <h1>Events Page</h1>
-    <ul>
-      {
-        events.map((event) => (
-          <li>
-            <Link href={`/events/${event.slug}`}>{event.title}</Link>
-          </li>
-        ))
-      }
-    </ul>
-  </div>
+<Layout title="events">
+  <PagesSection heading="Events">
+    <CollectionItemList showEvent hideDate={true} items={items}/>
+  </PagesSection>
 </Layout>

--- a/src/pages/news/index.astro
+++ b/src/pages/news/index.astro
@@ -1,7 +1,6 @@
 ---
 import { getCollection } from "astro:content";
 import Layout from "@/layouts/Layout.astro";
-import Link from "@/components/Link.astro";
 import type { CollectionEntry } from "astro:content";
 import payloadFetch from "@/utilities/payload-fetch";
 import PagesSection from "@/components/PagesSection.astro";

--- a/src/pages/reports/index.astro
+++ b/src/pages/reports/index.astro
@@ -5,7 +5,7 @@ import CollectionItemList from "@/components/CollectionItemList.astro";
 import PagesSection from "@/components/PagesSection.astro";
 import type { CollectionEntry } from "astro:content";
 import payloadFetch from "@/utilities/payload-fetch";
-import { reportMapper } from "@/utilities/reportMapper";
+import { reportMapper } from "@/utilities/collections";
 
 const collectionName = "reports";
 let reports: CollectionEntry<typeof collectionName>["data"][];
@@ -24,6 +24,6 @@ const items = reports.map(reportMapper);
 
 <Layout title="Reports">
   <PagesSection heading="Reports" color="gray-10">
-    <CollectionItemList items={items}/>
+    <CollectionItemList items={items} />
   </PagesSection>
 </Layout>

--- a/src/utilities/contentMapper.ts
+++ b/src/utilities/contentMapper.ts
@@ -26,18 +26,28 @@ type MapperConfig = {
   fileField?: string;
 };
 
-import { formatDate } from "./formatting";
+import { parseDateParts, type DateParts } from "./dates";
+
+function safeParse(input? : string | number | Date): DateParts | null {
+  if (!input) return null; 
+  const parts = parseDateParts(input);
+  return Number.isNaN(parts.raw.getTime()) ? null : parts; 
+} 
 
 export function contentMapper(
   data: ContentData,
   { baseUrl, dateField = "publishedAt", fileField }: MapperConfig
 ) {
+  const endSrc = (data as any).endDate; 
   const files: File[] = fileField ? data[fileField] : [];
+  const dateParts = parseDateParts(data[dateField] || data.publishedAt || '');
 
   return {
     title: data.title,
     content: data.content,
-    date: formatDate(data[dateField] || data.publishedAt),
+    date: safeParse(data[dateField] || data.publishedAt || ''),
+    startDate: safeParse(data.startDate || ''),
+    endDate: safeParse(endSrc),
     description: data.excerpt,
     image: files?.[0]?.file?.url,
     imageAlt: files?.[0]?.file?.alt || data.title,

--- a/src/utilities/dates.ts
+++ b/src/utilities/dates.ts
@@ -1,0 +1,43 @@
+export interface DateParts {
+  full: string;
+  month: string;
+  abbrMonth: string; 
+  day: number;
+  year: number;
+  raw: Date;
+}
+
+export function parseDateParts(dateInput: string | number | Date): DateParts {
+  const date = new Date(dateInput);
+
+  if (isNaN(date.getTime())) {
+    return {
+      full: '',
+      month: '',
+      abbrMonth: '',
+      day: NaN,
+      year: NaN, 
+      raw: date,
+    };
+  }
+
+  return {
+    full: date.toLocaleDateString('en-US', {
+      month: 'long',
+      day: 'numeric',
+      year: 'numeric'
+    }),
+    month: date.toLocaleString('en-US', { month: 'long' }),
+    abbrMonth: date.toLocaleString('en-US', { month: 'short' }),
+    day: date.getDate(),
+    year: date.getFullYear(), 
+    raw: date,
+  };
+}
+
+export function tryParseDateParts(input?: string | number | Date) {
+  if (!input) return null; 
+  const d = new Date(input);
+  if (Number.isNaN(d.getTime())) return null;
+  return parseDateParts(d);
+}

--- a/src/utilities/eventsMapper.ts
+++ b/src/utilities/eventsMapper.ts
@@ -1,0 +1,10 @@
+import type { CollectionEntry } from "astro:content";
+import { contentMapper } from "./contentMapper";
+
+export function eventsMapper(data: CollectionEntry<"events">["data"]) {
+  return contentMapper(data, {
+    baseUrl: "/events",
+    dateField: "eventsDate",
+    fileField: "eventsFiles",
+  });
+}


### PR DESCRIPTION
## Changes proposed in this pull request:

- [X] Update Events listing and single event page styling
- [X] Utilize CollectionList component since it can be reused in more places, create events section to hide/show if it's being using on the Events listing page
- [x] Add date helpers to create readable dates
- [x] Hide end date on Event pages if it's a null input
