### PR TITLE
feat: Render CMS Media uploads in site

### DIFF
--- a/.cloudgov/manifest.yml
+++ b/.cloudgov/manifest.yml
@@ -28,5 +28,6 @@ applications:
       APP_ENV: ((env))
       SITE: ((site))
       PAYLOAD_API_KEY: ((api_key))
+      PREVIEW_MODE: ((preview_mode))
       ASTRO_TELEMETRY_DISABLED: 1
     health-check-type: process

--- a/.cloudgov/vars/dev.yml
+++ b/.cloudgov/vars/dev.yml
@@ -2,3 +2,4 @@ instances: 1
 env: dev
 log_level: verbose
 node_env: development
+preview_mode: true

--- a/.env.example
+++ b/.env.example
@@ -6,3 +6,5 @@ NODE_ENV=development
 PAYLOAD_API_KEY='a-bot-api-key-from-pages-editor'
 PAYLOAD_SECRET='secret-key-used-for-auth-encryption'
 RENDER_MODE='server'
+PREVIEW_MODE=false
+LOCAL_DEV=true

--- a/src/components/RichText.astro
+++ b/src/components/RichText.astro
@@ -1,13 +1,58 @@
 ---
-import { convertLexicalToHTML } from "@payloadcms/richtext-lexical/html";
+import {
+  convertLexicalToHTML,
+  type HTMLConvertersFunction,
+} from "@payloadcms/richtext-lexical/html";
+import type { DefaultNodeTypes } from "@payloadcms/richtext-lexical";
 import sanitizeHtml from "sanitize-html";
+import upload from "./RichTextConverers/upload";
 
 const { content } = Astro.props;
+
+type NodeTypes = DefaultNodeTypes;
+
+const htmlConverters: HTMLConvertersFunction<NodeTypes> = ({
+  defaultConverters,
+}) => {
+  return {
+    ...defaultConverters,
+    upload: ({ node }) => upload({ node }),
+  };
+};
 ---
 
 <section
   class="usa-prose"
-  set:html={sanitizeHtml(convertLexicalToHTML({ data: content }), {
-    allowedTags: sanitizeHtml.defaults.allowedTags.concat(["img"]),
-  })}
+  set:html={sanitizeHtml(
+    convertLexicalToHTML({ data: content, converters: htmlConverters }),
+    {
+      allowedTags: sanitizeHtml.defaults.allowedTags.concat([
+        "img",
+        "svg",
+        "use",
+      ]),
+      allowedClasses: {
+        a: false,
+        div: false,
+        h1: false,
+        h2: false,
+        h3: false,
+        h4: false,
+        h5: false,
+        h6: false,
+        img: false,
+        li: false,
+        ol: false,
+        p: false,
+        span: false,
+        ul: false,
+      },
+      allowedAttributes: {
+        a: ["href", "name", "target", "download"],
+        img: ["src", "alt"],
+        use: ["href"],
+        svg: ["class", "aria-hidden", "focusable", "role", "img"],
+      },
+    }
+  )}
 />

--- a/src/components/RichTextConverers/upload.ts
+++ b/src/components/RichTextConverers/upload.ts
@@ -1,0 +1,125 @@
+import type { SerializedUploadNode } from "@payloadcms/richtext-lexical";
+import filePresent from "@uswds-images/usa-icons/file_present.svg";
+import { getMediaUrl } from "@/utilities/media";
+
+export interface UploadValueProps {
+  id: number;
+  alt: string;
+  caption: string | null;
+  _status: "published";
+  reviewReady: boolean;
+  prefix: string;
+  updatedAt: string;
+  createdAt: string;
+  url: string;
+  thumbnailURL: string;
+  filename: string;
+  mimeType: string;
+  filesize: number;
+  width: number;
+  height: number;
+  focalX: number;
+  focalY: number;
+  site: {
+    bucket: string;
+  };
+  sizes: {
+    thumbnail: Record<string, any>;
+    square: Record<string, any>;
+    small: Record<string, any>;
+    medium: Record<string, any>;
+    large: Record<string, any>;
+    xlarge: Record<string, any>;
+    og: Record<string, any>;
+  };
+}
+
+const imageMimeTypes = [
+  "image/jpeg",
+  "image/png",
+  "image/gif",
+  "image/webp",
+  "image/svg+xml",
+  "image/avif",
+  "image/tiff",
+  "image/bmp",
+  "image/x-icon",
+  "image/heic",
+  "image/heif",
+  "image/heif-sequence",
+  "image/heic-sequence",
+];
+
+const tag = (value: string) => `<span class="usa-tag">${value}</span>`;
+
+const formatMimeType = (type: string): string => {
+  const parts = type.split("/");
+  return tag(parts[parts.length - 1].toLowerCase());
+};
+
+const formatBytes = (bytes: number): string => {
+  if (bytes <= 0) return tag("O Bytes");
+
+  const units = [
+    { name: "GB", divisor: 1024 * 1024 * 1024 },
+    { name: "MB", divisor: 1024 * 1024 },
+    { name: "KB", divisor: 1024 },
+  ];
+
+  for (const unit of units) {
+    if (bytes >= unit.divisor) {
+      // Round to 1 decimal places and return with unit
+      return tag(`${(bytes / unit.divisor).toFixed(1)} ${unit.name}`);
+    }
+  }
+
+  // If less than 1 KB, return in bytes
+  return tag(`${bytes} Bytes`);
+};
+
+const upload = ({ node }: { node: SerializedUploadNode }): string => {
+  const value = node.value as UploadValueProps;
+
+  const url = getMediaUrl({
+    url: value.url,
+    filename: value.filename,
+    bucket: value.site.bucket,
+  });
+
+  const fileIcon = `
+    <img src="${filePresent.src}" width="${filePresent.width}" height="${filePresent.height}" alt="download file" />
+  `;
+
+  const container = (slot) => `
+    <div class="maxw-tablet">
+      ${slot}
+    </div>
+  `;
+
+  if (imageMimeTypes.includes(value.mimeType)) {
+    const component = container(`<img src="${url}" alt="${value.alt}" />`);
+    return component;
+  }
+
+  return container(`
+    <div class="usa-alert usa-alert--info usa-alert--slim usa-alert--no-icon">
+    <div class="usa-alert__body">
+      <h4 class="usa-alert__heading display-flex flex-row flex-align-center">
+        ${fileIcon} Download File
+      </h4>
+      <p class="usa-alert__text">
+        <a class="usa-link" href="${url}" download="true">
+          ${value.alt || value.filename}
+        </a>
+      </p>
+      <div class="usa-alert__text display-flex flex-column flex-align-end maxw-full">
+        <p class="usa-alert__text">
+          ${formatMimeType(value.mimeType)}
+          ${formatBytes(value.filesize)}
+        </p>
+      </div>
+    </div>
+  </div>`);
+};
+
+export default upload;

--- a/src/utilities/media.ts
+++ b/src/utilities/media.ts
@@ -1,0 +1,26 @@
+export const getMediaUrl = ({
+  url,
+  filename,
+  bucket,
+}: {
+  url: string;
+  filename: string;
+  bucket: string;
+}) => {
+  const isPreview = import.meta.env.PREVIEW_MODE === "true";
+  const isLocal = import.meta.env.LOCAL_DEV === "true";
+  const assetPath = `/~assets/${filename}`;
+
+  if (isPreview) {
+    return url;
+  }
+
+  if (isLocal) {
+    // Use mino's local preview server from to get the media url
+    const storageDomain = "http://localhost:9101";
+    const storagePath = `/api/v1/buckets/${bucket}/objects/download?preview=true&prefix=`;
+    return `${storageDomain}${storagePath}${assetPath}`;
+  }
+
+  return assetPath;
+};


### PR DESCRIPTION
Related to https://github.com/cloud-gov/pages-site-gantry/issues/37

## Changes proposed in this pull request:

- Adds upload converter to display images and file downloads in Rich Text component


## Screen shots

Large Size
<img width="603" height="546" alt="Screenshot 2025-08-18 at 16 12 29" src="https://github.com/user-attachments/assets/1c71a747-ece3-465c-981f-f655e0239d8a" />

Mobile
<img width="348" height="757" alt="Screenshot 2025-08-18 at 16 12 48" src="https://github.com/user-attachments/assets/66b168e8-d3c1-426e-b9db-198ee926d376" />

## Security considerations
N/a
