### PR TITLE
Feat add breadcrumbs

### DIFF
--- a/src/components/Breadcrumb.astro
+++ b/src/components/Breadcrumb.astro
@@ -1,0 +1,90 @@
+---
+import Link from "./Link.astro";
+import payloadFetch from "@/utilities/payload-fetch";
+
+const currentPath = Astro.url.pathname;
+
+// Build breadcrumb trail based on current path
+const buildBreadcrumbs = async () => {
+  const breadcrumbs = [
+    { text: "Home", url: "/", isCurrent: currentPath === "/" }
+  ];
+
+  // Skip if we're on home page
+  if (currentPath === "/") {
+    return breadcrumbs;
+  }
+
+  // Split path into segments
+  const pathSegments = currentPath.split("/").filter(Boolean);
+  
+  // Build breadcrumb trail
+  let currentUrl = "";
+  for (let i = 0; i < pathSegments.length; i++) {
+    const segment = pathSegments[i];
+    currentUrl += `/${segment}`;
+    
+    // Try to get the page title from Payload
+    let pageTitle = segment.replace(/-/g, " ").replace(/\b\w/g, l => l.toUpperCase());
+    
+    try {
+      // Check if it's a collection page first
+      if (["reports", "news", "events", "posts", "leadership"].includes(segment)) {
+        // This is a collection landing page
+        const collectionTitle = segment.charAt(0).toUpperCase() + segment.slice(1);
+        breadcrumbs.push({
+          text: collectionTitle,
+          url: currentUrl,
+          isCurrent: i === pathSegments.length - 1
+        });
+        continue;
+      }
+      
+      // Try to get page data from Payload
+      const response = await payloadFetch(`pages?where[slug][equals]=${segment}&limit=1`);
+      const pageData = await response.json();
+      
+      if (pageData.docs && pageData.docs.length > 0) {
+        pageTitle = pageData.docs[0].title;
+      }
+    } catch (error) {
+      console.warn(`Could not fetch page data for segment: ${segment}`);
+    }
+    
+    breadcrumbs.push({
+      text: pageTitle,
+      url: currentUrl,
+      isCurrent: i === pathSegments.length - 1
+    });
+  }
+  
+  return breadcrumbs;
+};
+
+const breadcrumbs = await buildBreadcrumbs();
+
+// Don't show breadcrumbs on home page
+if (currentPath === "/") {
+  return null;
+}
+---
+
+<div class="grid-container">
+  <nav class="usa-breadcrumb" aria-label="Breadcrumbs">
+    <ol class="usa-breadcrumb__list">
+      {breadcrumbs.map((crumb, index) => (
+        <li class="usa-breadcrumb__list-item">
+          {crumb.isCurrent ? (
+            <span class="usa-breadcrumb__current" aria-current="page">
+              {crumb.text}
+            </span>
+          ) : (
+            <Link href={crumb.url} className="usa-breadcrumb__link">
+              <span>{crumb.text}</span>
+            </Link>
+          )}
+        </li>
+      ))}
+    </ol>
+  </nav>
+</div>

--- a/src/components/Menu.astro
+++ b/src/components/Menu.astro
@@ -41,7 +41,7 @@ const { title, items } = Astro.props;
                   <button
                     class="usa-accordion__button usa-nav__link"
                     aria-expanded="false"
-                    aria-controls={`nav-${item.id || Math.random().toString(36).substr(2, 9)}`}
+                    aria-controls={`nav-${item.id || Math.random().toString(36).slice(2, 11)}`}
                   >
                     <span set:html={item.label} />
                   </button>

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -3,6 +3,7 @@ import { getCollection } from "astro:content";
 import type { CollectionEntry } from "astro:content";
 import GovIdentifier from "@/components/GovIdentifier.astro";
 import Menu from "@/components/Menu.astro";
+import Breadcrumb from "@/components/Breadcrumb.astro";
 import Footer from "@/components/Footer.astro";
 import Config from "@/config.astro";
 import payloadFetch from "@/utilities/payload-fetch";
@@ -58,6 +59,7 @@ const metaTitle = title
     <Config />
     <GovIdentifier />
     <Menu title={siteConfig.agencyName} items={menu.items} />
+    <Breadcrumb />
     <slot />
     <Footer />
   </body>


### PR DESCRIPTION
Closes https://github.com/cloud-gov/pages-site-gantry/issues/63

## Changes proposed in this pull request:

- [x] Adding Breadcrumb component
- [x] Tying in links to populate breadcrumbs depending on URL structure and page title(s)

## Things to check

- Test pages that have multiple /url/ strings to make sure they render correctily

## Security considerations

None, just adding breadcrumbs to the site
