### PR TITLE
fix: Search baseUrl when BASEURL env var is undefined

### DIFF
--- a/src/components/Search.astro
+++ b/src/components/Search.astro
@@ -7,7 +7,7 @@ import search from "@uswds-images/usa-icons-bg/search--white.svg";
 const { searchAffiliate } = Astro.props;
 const baseUrl = import.meta.env.LOCAL_DEV
   ? "/"
-  : import.meta.env.BASE_URL + "/";
+  : (import.meta.env.BASEURL || "") + "/";
 ---
 
 <form


### PR DESCRIPTION
## Changes proposed in this pull request:

- If the live site BASEURL env var in undefined, it returns an empty string so it properly constructs the '/search' path.

## Security considerations

None
