### PR TITLE
fix: Add clear buildpack cache check to CI

### DIFF
--- a/ci/tasks/deploy.sh
+++ b/ci/tasks/deploy.sh
@@ -7,11 +7,14 @@ cf auth
 
 cf t -o $CF_ORG -s $CF_SPACE
 
-# Get app guid
-app_guid=`cf app $CF_APP_NAME --guid`
+# Get app guid and clear buildpack cache if app exists
+if app_guid=$(cf app $CF_APP_NAME --guid 2>/dev/null); then
+  echo "Clearing $CF_APP_NAME buildpack cache"
 
-# Clear buildpack cache
-cf curl -X POST /v3/apps/$app_guid/actions/clear_buildpack_cache
+  cf curl -X POST /v3/apps/$app_guid/actions/clear_buildpack_cache
+else
+  echo "App $CF_APP_NAME not found, skipping buildpack cache clear"
+fi
 
 # Deploy
 cf push $CF_APP_NAME \


### PR DESCRIPTION
Related to #113 

## Changes proposed in this pull request:

- Fixes the preview deploy when launching new preview app in CI.
- Creates a check to not run the clear buildpack cache since the app does not exist yet.

## Security considerations

None
