### PR TITLE
feat: Adding side navigation to single pages

### DIFF
--- a/src/components/PageWithSideNav.astro
+++ b/src/components/PageWithSideNav.astro
@@ -1,0 +1,208 @@
+---
+import SideNav from "./SideNav.astro";
+import { payloadFetch } from "@/utilities/fetch/payload-fetch";
+import {
+  createNavFromPages,
+  organizeNavItems,
+  convertMenuToSideNav,
+} from "@/utilities/navigation";
+
+interface NavItem {
+  id: string;
+  label: string;
+  href: string;
+  children?: NavItem[];
+}
+
+interface Props {
+  heading?: string;
+  classes?: string;
+  id?: string;
+  color?: string;
+  align?: "center" | "left";
+  showSideNav?: boolean;
+  sideNavItems?: NavItem[];
+  currentPath?: string;
+  navTitle?: string;
+  sideNavId?: string;
+}
+
+const {
+  heading = false,
+  color = "white",
+  align = "left",
+  classes = "",
+  id = false,
+  showSideNav = true,
+  sideNavItems = [],
+  currentPath = Astro.url.pathname,
+  navTitle = "Page Navigation",
+  sideNavId = null,
+} = Astro.props;
+
+// Fetch navigation items from CMS if not provided
+let navItems = sideNavItems;
+let sideNavEnabled = showSideNav;
+let sideNavTitle = navTitle;
+
+if (showSideNav && sideNavItems.length === 0) {
+  try {
+    let sideNavResponse;
+
+    if (sideNavId) {
+      // Fetch specific page menu by ID
+      sideNavResponse = await payloadFetch(`page-menus/${sideNavId}`);
+    } else {
+      // Fallback to global side navigation
+      sideNavResponse = await payloadFetch("globals/side-navigation");
+    }
+
+    if (sideNavResponse.ok) {
+      const sideNavData = await sideNavResponse.json();
+
+      // Check if page menu is enabled
+      sideNavEnabled = sideNavData.enabled !== false;
+      sideNavTitle = sideNavData.title || "Page Navigation";
+
+      if (sideNavEnabled && sideNavData.items && sideNavData.items.length > 0) {
+        // Convert page menu items to nav format
+        navItems = convertMenuToSideNav(sideNavData.items);
+      } else if (sideNavEnabled && sideNavData.fallbackToAllPages) {
+        // Fallback to auto-generated navigation if enabled
+        const response = await payloadFetch(
+          "pages?limit=100&depth=0&sort=title",
+        );
+        if (response.ok) {
+          const { docs: pages } = await response.json();
+          const rawNavItems = createNavFromPages(pages);
+          navItems = organizeNavItems(rawNavItems);
+        }
+      }
+    }
+  } catch (error) {
+    console.warn("Could not fetch page menu configuration:", error);
+  }
+}
+---
+
+<section
+  class={`usa-section section section--${color} align-${align} ${classes}`}
+>
+  <div class="grid-container">
+    <div class="section__container">
+      {
+        sideNavEnabled && navItems.length > 0 ? (
+          <div class="page-with-sidenav">
+            <aside class="sidenav-container">
+              <SideNav
+                items={navItems}
+                currentPath={currentPath}
+                title={sideNavTitle}
+                id="sidenav"
+              />
+            </aside>
+            <main class="main-content">
+              <div class="section__intro">
+                {heading && <h1 class="margin-bottom-2">{heading}</h1>}
+              </div>
+              <div class="section__slot">
+                <slot />
+              </div>
+            </main>
+          </div>
+        ) : (
+          <>
+            <div class="section__intro">
+              {heading && <h1 class="margin-bottom-2">{heading}</h1>}
+            </div>
+            <div class="section__slot">
+              <slot />
+            </div>
+          </>
+        )
+      }
+    </div>
+  </div>
+</section>
+
+<style>
+  .usa-section {
+    padding-top: 2rem;
+  }
+
+  .page-with-sidenav {
+    display: grid;
+    grid-template-columns: 200px 1fr;
+    gap: 1.5rem;
+    align-items: start;
+    min-height: 400px;
+  }
+
+  .sidenav-container {
+    position: sticky;
+    top: 2rem;
+    z-index: 10;
+  }
+
+  .main-content {
+    min-width: 0; /* Prevents grid blowout */
+    max-width: none;
+  }
+
+  .section__slot {
+    padding: 1rem 0;
+  }
+
+  /* Responsive design */
+  @media (max-width: 1024px) {
+    .page-with-sidenav {
+      grid-template-columns: 240px 1fr;
+      gap: 2rem;
+    }
+  }
+
+  @media (max-width: 768px) {
+    .page-with-sidenav {
+      grid-template-columns: 1fr;
+      gap: 1.5rem;
+    }
+
+    .sidenav-container {
+      position: static;
+      order: 2;
+    }
+
+    .main-content {
+      order: 1;
+    }
+  }
+
+  @media (max-width: 480px) {
+    .page-with-sidenav {
+      gap: 1rem;
+    }
+  }
+
+  /* Align styles */
+  &.align-left .section__container {
+    text-align: left;
+    justify-items: start;
+  }
+
+  &.align-center .section__container {
+    .section__intro,
+    .section__content,
+    .section__slot,
+    .section__outro {
+      margin-left: auto;
+      margin-right: auto;
+      text-align: center;
+      justify-items: center;
+    }
+  }
+
+  /* Ensure proper spacing */
+  .section__intro h1 {
+    margin-top: 0;
+  }
+</style>

--- a/src/components/SideNav.astro
+++ b/src/components/SideNav.astro
@@ -1,0 +1,126 @@
+---
+import Link from "./Link.astro";
+
+interface NavItem {
+  id: string;
+  label: string;
+  href: string;
+  children?: NavItem[];
+}
+
+interface Props {
+  items: NavItem[];
+  currentPath?: string;
+  title?: string;
+  id?: string;
+}
+
+const {
+  items = [],
+  currentPath = "",
+  title = "Page Navigation",
+  id = "sidenav",
+} = Astro.props;
+
+// Helper function to check if a path is active
+const isActive = (href: string) => {
+  if (href === currentPath) return true;
+  if (currentPath.startsWith(href + "/")) return true;
+  return false;
+};
+
+// Helper function to check if any child is active
+const hasActiveChild = (item: NavItem): boolean => {
+  if (isActive(item.href)) return true;
+  if (item.children) {
+    return item.children.some((child) => hasActiveChild(child));
+  }
+  return false;
+};
+---
+
+<nav class="usa-sidenav" aria-label={title} id={id}>
+  <ul class="usa-sidenav__list">
+    {
+      items.map((item) => {
+        const isItemActive = isActive(item.href);
+        const hasActiveChildren = item.children ? hasActiveChild(item) : false;
+
+        return (
+          <li class="usa-sidenav__item">
+            {item.children && item.children.length > 0 ? (
+              // Dropdown parent - not clickable but shows active state
+              <span
+                className={`usa-sidenav__link ${hasActiveChildren ? "usa-current" : ""}`}
+              >
+                {item.label}
+              </span>
+            ) : (
+              // Regular link - clickable
+              <Link
+                href={item.href}
+                className={`usa-sidenav__link ${isItemActive ? "usa-current" : ""}`}
+                aria-current={isItemActive ? "page" : undefined}
+              >
+                {item.label}
+              </Link>
+            )}
+
+            {item.children && item.children.length > 0 && (
+              <ul class="usa-sidenav__sublist">
+                {item.children.map((child) => {
+                  const isChildActive = isActive(child.href);
+                  return (
+                    <li class="usa-sidenav__item">
+                      <Link
+                        href={child.href}
+                        className={`usa-sidenav__link ${isChildActive ? "usa-current" : ""}`}
+                        aria-current={isChildActive ? "page" : undefined}
+                      >
+                        {child.label}
+                      </Link>
+                    </li>
+                  );
+                })}
+              </ul>
+            )}
+          </li>
+        );
+      })
+    }
+  </ul>
+</nav>
+
+<style>
+  .usa-sidenav {
+    position: sticky;
+    top: 0;
+    height: fit-content;
+    max-height: calc(100vh - 2rem);
+  }
+
+  .usa-sidenav__list {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+  }
+
+  .usa-sidenav__item {
+    margin: 0;
+  }
+
+  /* Dropdown parent styling - looks like link but not clickable */
+  .usa-sidenav__item > span.usa-sidenav__link {
+    cursor: default;
+    display: block;
+    padding: 0.5rem 1rem;
+    text-decoration: none;
+  }
+
+  /* Hide side navigation on mobile */
+  @media (max-width: 768px) {
+    .usa-sidenav {
+      display: none;
+    }
+  }
+</style>

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -471,6 +471,45 @@ const preFooter = defineCollection({
   ),
 });
 
+const sideNavigations = defineCollection({
+  loader: collectionLoader("page-menus"),
+  schema: makeAllKeysNullable(
+    z.object({
+      id: z.string(),
+      name: z.string(),
+      title: z.string().optional(),
+      enabled: z.boolean().optional(),
+      items: z
+        .array(
+          z.object({
+            id: z.string(),
+            label: z.string(),
+            blockType: z.string(),
+            page: z.any().optional(),
+            url: z.string().optional(),
+            order: z.number().optional(),
+            subitems: z
+              .array(
+                z.object({
+                  id: z.string(),
+                  label: z.string(),
+                  blockType: z.string(),
+                  page: z.any().optional(),
+                  url: z.string().optional(),
+                  order: z.number().optional(),
+                }),
+              )
+              .optional(),
+          }),
+        )
+        .optional(),
+      updatedAt: z.string().datetime(),
+      createdAt: z.string().datetime(),
+      _status: z.enum(["draft", "published"]),
+    }),
+  ),
+});
+
 export const collections = {
   // site collections
   events,
@@ -479,6 +518,7 @@ export const collections = {
   posts,
   reports,
   resources,
+  sideNavigations,
   // site globals
   homepage,
   menu,

--- a/src/pages/[...slug].astro
+++ b/src/pages/[...slug].astro
@@ -1,7 +1,7 @@
 ---
 import Layout from "../layouts/Layout.astro";
 import { createGetStaticPathForPages, fetchPageSlug } from "@/utilities/fetch";
-import PagesSection from "@/components/PagesSection.astro";
+import PageWithSideNav from "@/components/PageWithSideNav.astro";
 import RichText from "@/components/RichText.astro";
 
 const { slug } = Astro.params;
@@ -23,8 +23,12 @@ export const getStaticPaths = createGetStaticPathForPages();
 ---
 
 <Layout title={pageTitle}>
-  <PagesSection>
-    <h1>{pageTitle}</h1>
+  <PageWithSideNav
+    heading={pageTitle}
+    showSideNav={true}
+    currentPath={`/${slug}`}
+    sideNavId={page.sideNavigation?.id}
+  >
     <RichText content={pageContent} />
-  </PagesSection>
+  </PageWithSideNav>
 </Layout>

--- a/src/pages/[slug].astro
+++ b/src/pages/[slug].astro
@@ -1,7 +1,7 @@
 ---
 // src/pages/[slug].astro
 import Layout from "@/layouts/Layout.astro";
-import PagesSection from "@/components/PagesSection.astro";
+import PageWithSideNav from "@/components/PageWithSideNav.astro";
 import { fetchSlug, createStaticPathsForPagesSlug } from "@/utilities/fetch";
 import RichText from "@/components/RichText.astro";
 import Media from "@/components/Media.astro";
@@ -17,8 +17,13 @@ export const getStaticPaths = createStaticPathsForPagesSlug();
 ---
 
 <Layout title={page.title}>
-  <PagesSection heading={page.title}>
+  <PageWithSideNav
+    heading={page.title}
+    showSideNav={true}
+    currentPath={`/${page.slug}`}
+    sideNavId={page.sideNavigation?.id}
+  >
     {page.image && <Media media={page.image} />}
     <RichText content={page.content} />
-  </PagesSection>
+  </PageWithSideNav>
 </Layout>

--- a/src/utilities/fetch/collectionLoader.ts
+++ b/src/utilities/fetch/collectionLoader.ts
@@ -1,19 +1,9 @@
-import { payloadFetch } from "./payload-fetch";
+import { payloadFetch, safeJsonParse } from "./payload-fetch";
 
 export function collectionLoader(apiPath: string) {
   return async () => {
     const response = await payloadFetch(`${apiPath}?limit=0`);
-
-    if (!response.ok) {
-      console.error(
-        `API call failed for ${apiPath}:`,
-        response.status,
-        response.statusText,
-      );
-      return [];
-    }
-
-    const data = await response.json();
+    const data = await safeJsonParse(response);
 
     if (apiPath.includes("globals")) {
       return [{ ...data, id: "main" }];

--- a/src/utilities/fetch/queries.ts
+++ b/src/utilities/fetch/queries.ts
@@ -1,5 +1,5 @@
 import type { HomePage, SiteConfig } from "@/env";
-import { payloadFetch } from "./payload-fetch";
+import { payloadFetch, safeJsonParse } from "./payload-fetch";
 
 // globals
 
@@ -23,7 +23,7 @@ export async function fetchPreFooter() {
 
 export async function fetchCollection(collectionName: string) {
   const response = await payloadFetch(`${collectionName}?limit=0`);
-  return await response.json();
+  return await safeJsonParse(response);
 }
 
 // slugs
@@ -36,12 +36,12 @@ export async function fetchSlug(collectionName: string, slug: string) {
   const response = await payloadFetch(
     `${collectionName}?where[slug][equals]=${slug}`,
   );
-  return processFetchResponse(await response.json());
+  return processFetchResponse(await safeJsonParse(response));
 }
 
 export async function fetchPageSlug(collectionName: string, slug: string) {
   const response = await payloadFetch(
     `${collectionName}?where[slug][equals]=${slug}&depth=1`,
   );
-  return processFetchResponse(await response.json());
+  return processFetchResponse(await safeJsonParse(response));
 }

--- a/src/utilities/fetch/staticPath.ts
+++ b/src/utilities/fetch/staticPath.ts
@@ -1,5 +1,5 @@
 import { type DataEntryMap, getCollection } from "astro:content";
-import { payloadFetch } from "./payload-fetch";
+import { payloadFetch, safeJsonParse } from "./payload-fetch";
 
 export function createGetStaticPath(collectionName: keyof DataEntryMap) {
   return async function () {
@@ -20,7 +20,7 @@ export function createPagingStaticPath(
 ) {
   return async function getStaticPaths() {
     const response = await payloadFetch(`${collectionName}?limit=0`);
-    const data = await response.json();
+    const data = await safeJsonParse(response);
     const totalItems = data.totalDocs || data.docs?.length || 0;
     const totalPages = Math.ceil(totalItems / pageSize);
 
@@ -39,7 +39,7 @@ export function processPagesResponse(data) {
 export function createGetStaticPathForPages() {
   return async function getStaticPaths() {
     const response = await payloadFetch("pages?limit=0");
-    const data = await response.json();
+    const data = await safeJsonParse(response);
     return processPagesResponse(data);
   };
 }
@@ -58,7 +58,7 @@ export function processPagesSlugResponse(data) {
 export function createStaticPathsForPagesSlug() {
   return async function getStaticPaths() {
     const res = await payloadFetch(`pages?limit=1000&depth=0`);
-    let data = await res.json();
+    let data = await safeJsonParse(res);
     return processPagesSlugResponse(data);
   };
 }

--- a/src/utilities/navigation.ts
+++ b/src/utilities/navigation.ts
@@ -1,0 +1,166 @@
+/**
+ * Navigation utilities for organizing and managing side navigation
+ */
+
+export interface NavItem {
+  id: string;
+  label: string;
+  href: string;
+  children?: NavItem[];
+  order?: number;
+  category?: string;
+}
+
+/**
+ * Organizes navigation items by category and sorts them
+ */
+export function organizeNavItems(items: NavItem[]): NavItem[] {
+  // Group items by category
+  const categorized = items.reduce(
+    (acc, item) => {
+      const category = item.category || "general";
+      if (!acc[category]) {
+        acc[category] = [];
+      }
+      acc[category].push(item);
+      return acc;
+    },
+    {} as Record<string, NavItem[]>,
+  );
+
+  // Sort items within each category and create organized structure
+  const organized: NavItem[] = [];
+
+  // Add general items first
+  if (categorized.general) {
+    organized.push(
+      ...categorized.general.sort((a, b) => (a.order || 0) - (b.order || 0)),
+    );
+  }
+
+  // Add other categories
+  Object.entries(categorized)
+    .filter(([category]) => category !== "general")
+    .sort(([a], [b]) => a.localeCompare(b))
+    .forEach(([category, items]) => {
+      const sortedItems = items.sort((a, b) => (a.order || 0) - (b.order || 0));
+      organized.push(...sortedItems);
+    });
+
+  return organized;
+}
+
+/**
+ * Creates a hierarchical navigation structure from flat page data
+ */
+export function createNavFromPages(pages: any[]): NavItem[] {
+  return pages
+    .filter((page) => page.slug && page.title)
+    .map((page) => ({
+      id: page.id.toString(),
+      label: page.title,
+      href: `/${page.slug}`,
+      order: page.order || 0,
+      category: page.category || "general",
+    }))
+    .sort((a, b) => a.label.localeCompare(b.label));
+}
+
+/**
+ * Finds the current page in navigation and marks it as active
+ */
+export function findActiveNavItem(
+  items: NavItem[],
+  currentPath: string,
+): NavItem | null {
+  for (const item of items) {
+    if (item.href === currentPath) {
+      return item;
+    }
+    if (item.children) {
+      const found = findActiveNavItem(item.children, currentPath);
+      if (found) return found;
+    }
+  }
+  return null;
+}
+
+/**
+ * Creates a breadcrumb trail from navigation items
+ */
+export function createBreadcrumbs(
+  items: NavItem[],
+  currentPath: string,
+): NavItem[] {
+  const breadcrumbs: NavItem[] = [];
+
+  function findPath(items: NavItem[], path: string[] = []): boolean {
+    for (const item of items) {
+      const newPath = [...path, item];
+
+      if (item.href === currentPath) {
+        breadcrumbs.push(...newPath);
+        return true;
+      }
+
+      if (item.children && findPath(item.children, newPath)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  findPath(items);
+  return breadcrumbs;
+}
+
+/**
+ * Converts Payload CMS menu items to side navigation format
+ */
+export function convertMenuToSideNav(menuItems: any[]): NavItem[] {
+  return menuItems
+    .map((item: any) => {
+      let href = "#";
+
+      // Handle different menu item types
+      if (item.blockType === "pageLink" && item.page) {
+        href = `/${item.page.slug}`;
+      } else if (item.blockType === "collectionLink") {
+        href = `/${item.page}`;
+      } else if (item.blockType === "externalLink" && item.url) {
+        href = item.url;
+      }
+
+      return {
+        id: item.id || Math.random().toString(36).substr(2, 9),
+        label: item.label,
+        href: href,
+        order: item.order || 0,
+        children: item.subitems
+          ? item.subitems
+              .sort((a: any, b: any) => (a.order || 0) - (b.order || 0))
+              .map((subitem: any) => {
+                let subHref = "#";
+                if (subitem.blockType === "pageLink" && subitem.page) {
+                  subHref = `/${subitem.page.slug}`;
+                } else if (subitem.blockType === "collectionLink") {
+                  subHref = `/${subitem.page}`;
+                } else if (
+                  subitem.blockType === "externalLink" &&
+                  subitem.url
+                ) {
+                  subHref = subitem.url;
+                }
+
+                return {
+                  id: subitem.id || Math.random().toString(36).substr(2, 9),
+                  label: subitem.label,
+                  href: subHref,
+                  order: subitem.order || 0,
+                };
+              })
+          : undefined,
+      };
+    })
+    .sort((a, b) => (a.order || 0) - (b.order || 0));
+}


### PR DESCRIPTION
## Changes proposed in this pull request:

- Built PageWithSideNav.astro - Smart layout component that fetches side navigation from Payload CMS with fallback to auto-generated nav
- Created SideNav.astro - USWDS-compliant navigation with hierarchical menus, active states, and mobile-responsive design
- Updated page templates - Replaced PagesSection with PageWithSideNav in [...slug].astro and [slug].astro
- Added navigation utilities - Created navigation.ts with helpers for organizing nav items, converting CMS data, and managing breadcrumbs
- Simplified mobile experience - Removed toggle component in favor of clean CSS-based responsive behavior that hides nav on mobile

## Security considerations

None
