### PR TITLE
feat: Add in-page navigation component

### DIFF
--- a/src/components/InPageNavigation.astro
+++ b/src/components/InPageNavigation.astro
@@ -1,0 +1,57 @@
+---
+interface Props {
+  minimumHeadingCount?: number;
+  show?: boolean;
+  titleText?: string;
+  mainContentSelector?: string;
+}
+
+const {
+  minimumHeadingCount = 2,
+  show = true,
+  titleText = "On this page",
+  mainContentSelector = "#main-content",
+} = Astro.props;
+---
+
+{
+  show && (
+    <>
+      <aside
+        class="usa-in-page-nav"
+        data-title-text={titleText}
+        data-title-heading-level="h4"
+        data-main-content-selector={mainContentSelector}
+        data-minimum-heading-count={minimumHeadingCount}
+        data-root-margin="0px 0px -80% 0px"
+        data-threshold="0"
+      />
+      <script is:inline>
+        {`(function() {
+          function renameAnchorIds() {
+            setTimeout(function() {
+              var anchors = document.querySelectorAll('.usa-anchor[id$="-2"]');
+              var nav = document.querySelector('.usa-in-page-nav');
+              anchors.forEach(function(anchor) {
+                var oldId = anchor.id;
+                var newId = oldId.replace(/-2$/, '-link');
+                anchor.id = newId;
+                if (nav) {
+                  var links = nav.querySelectorAll('a[href="#' + oldId + '"]');
+                  links.forEach(function(link) {
+                    link.setAttribute('href', '#' + newId);
+                  });
+                }
+              });
+            }, 1500);
+          }
+          if (document.readyState === 'loading') {
+            document.addEventListener('DOMContentLoaded', renameAnchorIds);
+          } else {
+            renameAnchorIds();
+          }
+        })();`}
+      </script>
+    </>
+  )
+}

--- a/src/components/PagesSection.astro
+++ b/src/components/PagesSection.astro
@@ -27,18 +27,30 @@ const {
   class={`usa-section section section--${color} align-${align} ${classes}`}
 >
   <div class="grid-container">
-    <div class="section__container">
-      <div class="section__intro">
-        {heading && <h1 class="margin-bottom-2">{heading}</h1>}
+    <div class="grid-row">
+      <div class="grid-col-8">
+        <div class="section__container">
+          <div class="section__intro">
+            {heading && <h1 class="margin-bottom-2">{heading}</h1>}
+          </div>
+          <div class="section__slot">
+            <slot />
+          </div>
+        </div>
       </div>
-      <div class="section__slot">
-        <slot />
+      <div class="grid-col-4">
+        <slot name="sidebar" />
       </div>
     </div>
   </div>
 </section>
 
 <style>
+  /* Remove top padding from usa-section */
+  section {
+    padding-top: 2rem;
+  }
+
   &.align-left .section__container {
     text-align: left;
     justify-items: start;

--- a/src/components/RichText.astro
+++ b/src/components/RichText.astro
@@ -17,6 +17,19 @@ const htmlConverters: HTMLConvertersFunction<NodeTypes> = ({
   return {
     ...defaultConverters,
     upload: ({ node }) => upload({ node }),
+    heading: ({ node }) => {
+      const getTextContent = (child) => {
+        if (child.text) return child.text;
+        if (child.children) return child.children.map(getTextContent).join("");
+        return "";
+      };
+      const text = node.children?.map(getTextContent).join("") || "";
+      const id = text
+        .toLowerCase()
+        .replace(/\s+/g, "-")
+        .replace(/[^a-z0-9-]/g, "");
+      return `<${node.tag} id="${id}">${text}</${node.tag}>`;
+    },
   };
 };
 ---
@@ -52,6 +65,12 @@ const htmlConverters: HTMLConvertersFunction<NodeTypes> = ({
         img: ["src", "alt"],
         use: ["href"],
         svg: ["class", "aria-hidden", "focusable", "role", "img"],
+        h1: ["id"],
+        h2: ["id"],
+        h3: ["id"],
+        h4: ["id"],
+        h5: ["id"],
+        h6: ["id"],
       },
     },
   )}

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -80,6 +80,7 @@ const events = defineCollection({
       registrationUrl: z.string(),
       content: z.any(),
       reviewReady: z.boolean(),
+      showInPageNav: z.boolean().optional(),
       updatedAt: z.string().datetime(),
       createdAt: z.string().datetime(),
       _status: z.enum(["draft", "published"]),
@@ -120,6 +121,7 @@ const news = defineCollection({
       content: z.any(), // content is a lexical object
       site: z.any(),
       reviewReady: z.boolean(),
+      showInPageNav: z.boolean().optional(),
       publishedAt: z.string().datetime(),
       slug: z.string(),
       slugLock: z.boolean(),
@@ -142,6 +144,7 @@ const posts = defineCollection({
       site: z.any(),
       content: z.any(), // content is a lexical object
       reviewReady: z.boolean(),
+      showInPageNav: z.boolean().optional(),
       authors: z.any(),
       populatedAuthors: z.any(),
       publishedAt: z.string().datetime(),
@@ -181,6 +184,7 @@ const reports = defineCollection({
       site: z.any(), // siteField, can be any
       content: z.any(), // richText, can be any
       reviewReady: z.boolean(),
+      showInPageNav: z.boolean().optional(),
       publishedAt: z.string().datetime(),
       updatedAt: z.string().datetime().optional(),
       createdAt: z.string().datetime().optional(),
@@ -210,6 +214,7 @@ const resources = defineCollection({
       site: z.any(), // siteField, can be any
       content: z.any(), // richText, can be any
       reviewReady: z.boolean(),
+      showInPageNav: z.boolean().optional(),
       publishedAt: z.string().datetime(),
       updatedAt: z.string().datetime().optional(),
       createdAt: z.string().datetime().optional(),

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -55,7 +55,13 @@ if (!Astro.isPrerendered) {
 preFooter = preFooterMapper(preFooterResponseData);
 
 // TODO: Add meta title and description to site config
-const { title, description, socialImage, canonical } = Astro.props;
+const {
+  title,
+  description,
+  socialImage,
+  canonical,
+  useInPageNav = false,
+} = Astro.props;
 const metaTitle = title
   ? `${title} | ${siteConfig.agencyName || "Agency Homepage"}`
   : siteConfig.agencyName || "Agency Homepage";
@@ -96,9 +102,20 @@ const socialImageUrl = socialImage ? getMediaUrl(socialImage) : null;
       searchAffiliate={siteConfig.searchAffiliate}
     />
     <Breadcrumb />
-    <main id="main-content">
-      <slot />
-    </main>
+    {
+      useInPageNav ? (
+        <div class="usa-in-page-nav-container">
+          <slot name="in-page-nav" />
+          <main id="main-content">
+            <slot />
+          </main>
+        </div>
+      ) : (
+        <main id="main-content">
+          <slot />
+        </main>
+      )
+    }
     <Footer preFooter={preFooter} />
     {
       siteConfig.dapAgencyCode && (
@@ -111,11 +128,25 @@ const socialImageUrl = socialImage ? getMediaUrl(socialImage) : null;
   </body>
 
   <style>
-    html,
-    body {
-      margin: 0;
-      width: 100%;
-      height: 100%;
+    .usa-in-page-nav-container {
+      position: relative;
+      max-width: 75rem;
+      margin-left: auto;
+      margin-right: auto;
+    }
+
+    @media (min-width: 1024px) {
+      .usa-in-page-nav {
+        position: sticky;
+        top: 2rem;
+        right: calc(50% - 32rem - 1rem);
+      }
+    }
+
+    @media (max-width: 1023px) {
+      .usa-in-page-nav {
+        display: none;
+      }
     }
   </style>
   <script>

--- a/src/pages/events/[slug].astro
+++ b/src/pages/events/[slug].astro
@@ -1,10 +1,15 @@
 ---
-import { createGetStaticPath, fetchSlug } from "@/utilities/fetch";
+import {
+  createGetStaticPath,
+  fetchSlug,
+  eventsMapper,
+} from "@/utilities/fetch";
 import { tryParseDateParts } from "@/utilities/dates";
 import PagesSection from "@/components/PagesSection.astro";
 import Layout from "@/layouts/Layout.astro";
 import RichText from "@/components/RichText.astro";
 import Tags from "@/components/Tags.astro";
+import InPageNavigation from "@/components/InPageNavigation.astro";
 import PreviewReload from "@/components/PreviewReload.astro";
 import type { CollectionEntry } from "astro:content";
 
@@ -28,6 +33,7 @@ if (!Astro.isPrerendered) {
   ({ data } = Astro.props);
 }
 
+const event = eventsMapper(data);
 const start = tryParseDateParts(data.startDate);
 const end = tryParseDateParts(data.endDate);
 
@@ -36,7 +42,14 @@ export const getStaticPaths = createGetStaticPath("events");
 export const prerender = import.meta.env.PREVIEW_MODE || false;
 ---
 
-<Layout title="events">
+<Layout title={event.title} useInPageNav={event.showInPageNav}>
+  {
+    event.showInPageNav && (
+      <Fragment slot="in-page-nav">
+        <InPageNavigation />
+      </Fragment>
+    )
+  }
   <PagesSection heading={data.title}>
     {
       data.categories && data.categories.length > 0 && (

--- a/src/pages/news/[slug].astro
+++ b/src/pages/news/[slug].astro
@@ -1,9 +1,10 @@
 ---
 import { type CollectionEntry } from "astro:content";
 import Layout from "@/layouts/Layout.astro";
-import { createGetStaticPath, fetchSlug } from "@/utilities/fetch";
+import { createGetStaticPath, fetchSlug, newsMapper } from "@/utilities/fetch";
 import RichText from "@/components/RichText.astro";
 import PagesSection from "@/components/PagesSection.astro";
+import InPageNavigation from "@/components/InPageNavigation.astro";
 import Media from "@/components/Media.astro";
 import PreviewReload from "@/components/PreviewReload.astro";
 
@@ -21,13 +22,22 @@ if (!Astro.isPrerendered) {
 
 export const getStaticPaths = createGetStaticPath("news");
 
+const newsItem = newsMapper(data);
+
 export const prerender = import.meta.env.PREVIEW_MODE || false;
 ---
 
-<Layout title={data.title}>
+<Layout title={newsItem.title} useInPageNav={newsItem.showInPageNav}>
+  {
+    newsItem.showInPageNav && (
+      <Fragment slot="in-page-nav">
+        <InPageNavigation />
+      </Fragment>
+    )
+  }
   <PagesSection>
     <div class="flex-column margin-bottom-5">
-      <h1 set:text={data.title} />
+      <h1 set:text={newsItem.title} />
     </div>
     {data.image && <Media media={data.image} />}
     <RichText content={data.content} />

--- a/src/pages/posts/[slug].astro
+++ b/src/pages/posts/[slug].astro
@@ -1,9 +1,10 @@
 ---
 import { type CollectionEntry } from "astro:content";
 import Layout from "@/layouts/Layout.astro";
-import { createGetStaticPath, fetchSlug } from "@/utilities/fetch";
+import { createGetStaticPath, fetchSlug, postsMapper } from "@/utilities/fetch";
 import RichText from "@/components/RichText.astro";
 import PagesSection from "@/components/PagesSection.astro";
+import InPageNavigation from "@/components/InPageNavigation.astro";
 import Media from "@/components/Media.astro";
 import PreviewReload from "@/components/PreviewReload.astro";
 
@@ -21,16 +22,25 @@ if (!Astro.isPrerendered) {
 
 export const getStaticPaths = createGetStaticPath("posts");
 
+const post = postsMapper(data);
+
 export const prerender = import.meta.env.PREVIEW_MODE || false;
 ---
 
-<Layout title={data.title}>
+<Layout title={post.title} useInPageNav={post.showInPageNav}>
+  {
+    post.showInPageNav && (
+      <Fragment slot="in-page-nav">
+        <InPageNavigation />
+      </Fragment>
+    )
+  }
   <PagesSection>
     <div class="flex-column margin-bottom-5">
-      <h1 set:text={data.title} />
+      <h1 set:text={post.title} />
     </div>
     {data.image && <Media media={data.image} />}
-    <RichText content={data.content} />
+    <RichText content={post.content} />
   </PagesSection>
 </Layout>
 

--- a/src/pages/reports/[slug].astro
+++ b/src/pages/reports/[slug].astro
@@ -11,6 +11,7 @@ import PagesSection from "@/components/PagesSection.astro";
 import Tags, { type Tag } from "@/components/Tags.astro";
 import Media from "@/components/Media.astro";
 import PreviewReload from "@/components/PreviewReload.astro";
+import InPageNavigation from "@/components/InPageNavigation.astro";
 
 const { slug } = Astro.params;
 const collectionName = "reports";
@@ -31,7 +32,14 @@ const report = reportMapper(data);
 export const prerender = import.meta.env.PREVIEW_MODE || false;
 ---
 
-<Layout title={report.title}>
+<Layout title={report.title} useInPageNav={report.showInPageNav}>
+  {
+    report.showInPageNav && (
+      <Fragment slot="in-page-nav">
+        <InPageNavigation />
+      </Fragment>
+    )
+  }
   <PagesSection>
     <div class="flex-column margin-bottom-5">
       <h1 set:text={report.title} />
@@ -45,6 +53,7 @@ export const prerender = import.meta.env.PREVIEW_MODE || false;
       </ul>
     </div>
     <RichText content={report.content} />
+    <Fragment slot="sidebar"></Fragment>
   </PagesSection>
 </Layout>
 

--- a/src/pages/resources/[slug].astro
+++ b/src/pages/resources/[slug].astro
@@ -9,6 +9,7 @@ import {
 import RichText from "@/components/RichText.astro";
 import PagesSection from "@/components/PagesSection.astro";
 import Tags, { type Tag } from "@/components/Tags.astro";
+import InPageNavigation from "@/components/InPageNavigation.astro";
 import Media from "@/components/Media.astro";
 
 const { slug } = Astro.params;
@@ -30,7 +31,14 @@ const resource = resourceMapper(data);
 export const prerender = true;
 ---
 
-<Layout title={resource.title}>
+<Layout title={resource.title} useInPageNav={resource.showInPageNav}>
+  {
+    resource.showInPageNav && (
+      <Fragment slot="in-page-nav">
+        <InPageNavigation />
+      </Fragment>
+    )
+  }
   <PagesSection>
     <div class="flex-column margin-bottom-5">
       <h1 set:text={resource.title} />

--- a/src/utilities/fetch/contentMapper.ts
+++ b/src/utilities/fetch/contentMapper.ts
@@ -73,6 +73,7 @@ export function eventsMapper(data: any) {
   return {
     ...mapped,
     description: data.description || data.excerpt || "",
+    showInPageNav: data.showInPageNav ?? true,
   };
 }
 
@@ -89,19 +90,27 @@ export function leadershipMapper(data: CollectionEntry<"leadership">["data"]) {
 }
 
 export function newsMapper(data: CollectionEntry<"news">["data"]) {
-  return contentMapper(data, {
+  const mapped = contentMapper(data, {
     baseUrl: "/news",
     dateField: "newsDate",
     fileField: "newsFiles",
   });
+  return {
+    ...mapped,
+    showInPageNav: data.showInPageNav ?? true,
+  };
 }
 
 export function postsMapper(data: CollectionEntry<"posts">["data"]) {
-  return contentMapper(data, {
+  const mapped = contentMapper(data, {
     baseUrl: "/posts",
     dateField: "postsDate",
     fileField: "postsFiles",
   });
+  return {
+    ...mapped,
+    showInPageNav: data.showInPageNav ?? true,
+  };
 }
 
 export function reportMapper(data: CollectionEntry<"reports">["data"]) {
@@ -119,6 +128,7 @@ export function reportMapper(data: CollectionEntry<"reports">["data"]) {
       label: c.title,
       url: `/reports?category=${c.slug}`,
     })),
+    showInPageNav: data.showInPageNav ?? true,
   };
 }
 
@@ -137,5 +147,6 @@ export function resourceMapper(data: CollectionEntry<"resources">["data"]) {
       label: c.title,
       url: `/resources?category=${c.slug}`,
     })),
+    showInPageNav: data.showInPageNav ?? true,
   };
 }


### PR DESCRIPTION
## Changes proposed in this pull request:

- Added InPageNavigation.astro component using USWDS in-page navigation with configurable heading count and title text, plus script to rename anchor IDs from "-2" suffix to "-link" for better URL handling
- Added showInPageNav optional boolean field to Events, News, Posts, Reports, and Resources collections in the content config schema, defaulting to true in the mappers
- Updated Layout.astro to conditionally render an in-page navigation container with sticky positioning on desktop (hidden on mobile), wrapping the main content when useInPageNav is enabled
- Enhanced RichText.astro to automatically generate anchor IDs for all heading elements (h1-h6) by converting text to lowercase kebab-case, enabling native USWDS in-page navigation functionality
- Updated all collection page templates (Events, News, Posts, Reports, Resources) to conditionally render the InPageNavigation component based on the showInPageNav field, and updated PagesSection to support a sidebar slot for the navigation positioning

## Security considerations

None
