### PR TITLE
chore: Remove link from tags

### DIFF
--- a/src/components/Tags.astro
+++ b/src/components/Tags.astro
@@ -1,4 +1,5 @@
 ---
+// TODO: Convert back to links when filtering is implemented
 import Link from "@/components/Link.astro";
 
 export interface Tag {
@@ -17,9 +18,7 @@ const { tags } = Astro.props;
     if (tag.url) {
       return (
         <li class="usa-collection__meta-item">
-          <Link href={tag.url} className="usa-link">
-            <span class="usa-tag">{tag.label}</span>
-          </Link>
+          <span class="usa-tag">{tag.label}</span>
         </li>
       );
     }


### PR DESCRIPTION
Closes #141 

## Changes proposed in this pull request:

- Removed link from tags because, currently, they didn't do anything and it would confuse someone using assistive technology

## Things to check

- When we update the collections to filter based on tags, add the link logic back in

## Security considerations

None
