### PR TITLE
feat: User-generated general collections

### DIFF
--- a/src/components/Menu.astro
+++ b/src/components/Menu.astro
@@ -58,6 +58,8 @@ const { title, items = [], searchAccessKey, searchAffiliate } = Astro.props;
                         subHref = `/${subitem.page.slug}`;
                       } else if (subitem.blockType === "collectionLink") {
                         subHref = `/${subitem.page}`;
+                      } else if (subitem.blockType === "customCollectionLink") {
+                        subHref = `/${subitem.customCollection?.slug || ""}`;
                       }
 
                       const isSubActive =
@@ -95,6 +97,9 @@ const { title, items = [], searchAccessKey, searchAffiliate } = Astro.props;
               label = item.label;
             } else if (item.blockType === "collectionLink") {
               href = `/${item.page}`;
+              label = item.label;
+            } else if (item.blockType === "customCollectionLink") {
+              href = `/${item.customCollection?.slug || ""}`;
               label = item.label;
             }
 

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -398,6 +398,15 @@ const siteConfig = defineCollection({
         searchAffiliate: z.any().optional(),
         dapAgencyCode: z.string().optional(),
         dapSubAgencyCode: z.string().optional(),
+        collectionDisplayNames: z
+          .array(
+            z.object({
+              collectionSlug: z.string(),
+              displayName: z.string(),
+              customSlug: z.string().optional(),
+            }),
+          )
+          .optional(),
       })
       .partial(),
   ),
@@ -501,6 +510,91 @@ const preFooter = defineCollection({
   ),
 });
 
+const general = defineCollection({
+  loader: collectionLoader("general"),
+  schema: makeAllKeysNullable(
+    z.object({
+      id: z.string(),
+      title: z.string(),
+      excerpt: z.string().optional(),
+      image: mvCustom.optional(),
+      files: z
+        .array(
+          z.object({
+            id: z.string(),
+            file: mvCustom,
+            label: z.string().optional(),
+          }),
+        )
+        .optional(),
+      slug: z.string(),
+      slugLock: z.boolean().optional(),
+      contentDate: z.string().datetime().optional(),
+      location: z.string().optional(),
+      categories: z.array(cCustom.optional()).optional(),
+      site: z.any(),
+      content: z.any().optional(), // richText
+      reviewReady: z.boolean().optional(),
+      showInPageNav: z.boolean().optional(),
+      publishedAt: z.string().datetime().optional(),
+      updatedAt: z.string().datetime(),
+      createdAt: z.string().datetime(),
+      _status: z.enum(["draft", "published"]),
+    }),
+  ),
+});
+
+const customCollections = defineCollection({
+  loader: collectionLoader("custom-collections"),
+  schema: makeAllKeysNullable(
+    z.object({
+      id: z.string(),
+      title: z.string(),
+      slug: z.string(),
+      description: z.string().optional(),
+      site: z.any(),
+      reviewReady: z.boolean().optional(),
+      updatedAt: z.string().datetime(),
+      createdAt: z.string().datetime(),
+      _status: z.enum(["draft", "published"]),
+    }),
+  ),
+});
+
+const customCollectionPages = defineCollection({
+  loader: collectionLoader("custom-collection-pages"),
+  schema: makeAllKeysNullable(
+    z.object({
+      id: z.string(),
+      collectionConfig: z.any(), // relationship to custom-collections
+      title: z.string(),
+      excerpt: z.string().optional(),
+      image: mvCustom.optional(),
+      files: z
+        .array(
+          z.object({
+            id: z.string(),
+            file: mvCustom,
+            label: z.string().optional(),
+          }),
+        )
+        .optional(),
+      slug: z.string(),
+      slugLock: z.boolean().optional(),
+      contentDate: z.string().datetime().optional(),
+      categories: z.array(cCustom.optional()).optional(),
+      site: z.any(),
+      content: z.any().optional(), // richText
+      reviewReady: z.boolean().optional(),
+      showInPageNav: z.boolean().optional(),
+      publishedAt: z.string().datetime().optional(),
+      updatedAt: z.string().datetime(),
+      createdAt: z.string().datetime(),
+      _status: z.enum(["draft", "published"]),
+    }),
+  ),
+});
+
 const sideNavigations = defineCollection({
   loader: collectionLoader("page-menus"),
   schema: makeAllKeysNullable(
@@ -588,6 +682,8 @@ export const collections = {
   posts,
   reports,
   resources,
+  customCollections,
+  customCollectionPages,
   sideNavigations,
   // site globals
   homepage,

--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -155,6 +155,11 @@ export interface SiteConfig {
   primaryFont?: string;
   favicon?: any;
   logo?: any;
+  collectionDisplayNames?: {
+    collectionSlug: string;
+    displayName: string;
+    customSlug?: string;
+  }[];
 }
 
 export enum SocialPlatform {

--- a/src/pages/[collectionSlug]/[slug].astro
+++ b/src/pages/[collectionSlug]/[slug].astro
@@ -1,0 +1,180 @@
+---
+import {
+  fetchCustomCollectionPageBySlug,
+  createCustomCollectionPageMapper,
+  fetchSlug,
+} from "@/utilities/fetch";
+import { tryParseDateParts } from "@/utilities/dates";
+import PagesSection from "@/components/PagesSection.astro";
+import Layout from "@/layouts/Layout.astro";
+import RichText from "@/components/RichText.astro";
+import Tags from "@/components/Tags.astro";
+import Media from "@/components/Media.astro";
+import InPageNavigation from "@/components/InPageNavigation.astro";
+import PreviewReload from "@/components/PreviewReload.astro";
+import { fetchCollection } from "@/utilities/fetch";
+
+const { collectionSlug, slug: pageSlug } = Astro.params;
+
+// Check if this slug matches a custom collection config
+const collectionConfig = await fetchSlug(
+  "custom-collections",
+  collectionSlug || "",
+);
+
+if (!collectionConfig) {
+  return Astro.redirect("/404");
+}
+
+// Fetch the specific page
+let data: any;
+
+if (!Astro.isPrerendered) {
+  data = await fetchCustomCollectionPageBySlug(
+    collectionConfig.id,
+    pageSlug || "",
+  );
+  if (!data) return Astro.redirect("/404");
+} else {
+  // @ts-expect-error
+  ({ data } = Astro.props);
+}
+
+// Map the page
+const mapper = createCustomCollectionPageMapper(collectionSlug || "");
+const item = mapper(data);
+const contentDate = data.contentDate
+  ? tryParseDateParts(data.contentDate)
+  : null;
+
+export async function getStaticPaths() {
+  // Fetch all custom collection configs and their pages to generate static paths
+  try {
+    const configsData = await fetchCollection("custom-collections");
+    const configs = configsData?.docs || [];
+
+    const paths: any[] = [];
+
+    for (const config of configs) {
+      const pagesData = await fetchCollection(
+        `custom-collection-pages?where[collectionConfig][equals]=${config.id}&limit=0`,
+      );
+      const pages = pagesData?.docs || [];
+
+      for (const page of pages) {
+        if (page.slug) {
+          paths.push({
+            params: {
+              collectionSlug: config.slug,
+              slug: page.slug,
+            },
+            props: { data: page, collectionConfig: config },
+          });
+        }
+      }
+    }
+
+    return paths;
+  } catch (error) {
+    console.warn(
+      "Could not generate static paths for custom collection pages:",
+      error,
+    );
+    return [];
+  }
+}
+
+export const prerender = import.meta.env.PREVIEW_MODE || false;
+---
+
+<Layout title={item.title} useInPageNav={item.showInPageNav}>
+  {
+    item.showInPageNav && (
+      <Fragment slot="in-page-nav">
+        <InPageNavigation />
+      </Fragment>
+    )
+  }
+  <PagesSection heading={data.title}>
+    <div class="flex-column margin-bottom-5">
+      {data.image && <Media media={data.image} />}
+      {item.date && <p class="font-sans-sm text-italic" set:text={item.date} />}
+      {
+        data.categories && data.categories.length > 0 && (
+          <ul
+            class="usa-collection__meta display-flex margin-top-2"
+            aria-label="More information"
+          >
+            <Tags
+              tags={data.categories.map((cat) => ({
+                label: cat.title,
+                url: `/${collectionSlug}?category=${cat.slug}`,
+              }))}
+            />
+          </ul>
+        )
+      }
+    </div>
+
+    {
+      contentDate && (
+        <div
+          class="usa-summary-box maxw-tablet margin-bottom-2"
+          role="region"
+          aria-labelledby={`content-details-${itemSlug}`}
+        >
+          <div class="usa-summary-box__body">
+            <h2
+              class="usa-summary-box__heading"
+              id={`content-details-${itemSlug}`}
+            >
+              Details
+            </h2>
+            <div class="usa-summary-box__text">
+              <ul class="usa-list">
+                {contentDate && (
+                  <li>
+                    <b>Date:</b> {contentDate.full}
+                  </li>
+                )}
+              </ul>
+            </div>
+          </div>
+        </div>
+      )
+    }
+
+    {data.excerpt && <p class="margin-bottom-2">{data.excerpt}</p>}
+
+    {
+      data.content && (
+        <section class="margin-top-4">
+          <RichText content={data.content} />
+        </section>
+      )
+    }
+
+    {
+      data.files && data.files.length > 0 && (
+        <section class="margin-top-4">
+          <h3>Files</h3>
+          <ul class="usa-list">
+            {data.files.map((fileItem) => (
+              <li>
+                <a
+                  href={fileItem.file?.url}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  {fileItem.label || fileItem.file?.filename || "Download"}
+                </a>
+              </li>
+            ))}
+          </ul>
+        </section>
+      )
+    }
+  </PagesSection>
+</Layout>
+
+<PreviewReload />

--- a/src/pages/[collectionSlug]/index.astro
+++ b/src/pages/[collectionSlug]/index.astro
@@ -1,0 +1,133 @@
+---
+import CollectionItemList from "@/components/CollectionItemList.astro";
+import PagesSection from "@/components/PagesSection.astro";
+import Layout from "@/layouts/Layout.astro";
+import PaginationNav from "@/components/PaginationNav.astro";
+import PageWithSideNav from "@/components/PageWithSideNav.astro";
+import RichText from "@/components/RichText.astro";
+import Media from "@/components/Media.astro";
+import {
+  fetchCustomCollectionPages,
+  createCustomCollectionPageMapper,
+  fetchCollection,
+  fetchSlug,
+} from "@/utilities/fetch";
+import { paginate } from "@/utilities/pagination";
+
+export const PAGE_SIZE = import.meta.env.PAGE_SIZE || 10;
+
+const { collectionSlug } = Astro.params;
+
+// Check if this slug matches a custom collection config
+const collectionConfig = await fetchSlug(
+  "custom-collections",
+  collectionSlug || "",
+);
+
+let page = null;
+let collectionPages: any[] = [];
+let items: any[] = [];
+let currentPage = 1;
+let totalPages = 1;
+let hasPaginationNav = false;
+
+if (!collectionConfig) {
+  // Check if this is a regular page - if so, render it here since this route matched first
+  page = await fetchSlug("pages", collectionSlug || "");
+
+  if (!page) {
+    return Astro.redirect("/404");
+  }
+} else {
+  // Fetch pages for this custom collection
+  const collectionPagesData = await fetchCustomCollectionPages(
+    collectionConfig.id,
+  );
+  collectionPages = collectionPagesData?.docs || [];
+
+  // Sort by publishedAt
+  const sorted = collectionPages.sort((a: any, b: any) => {
+    return (
+      new Date(b.publishedAt || 0).getTime() -
+      new Date(a.publishedAt || 0).getTime()
+    );
+  });
+
+  // Paginate
+  currentPage = 1;
+  hasPaginationNav = sorted.length >= PAGE_SIZE;
+  const paginationResult = paginate(sorted, currentPage, PAGE_SIZE);
+  totalPages = paginationResult.totalPages;
+  const paginatedItems = paginationResult.paginatedItems;
+
+  // Map items
+  const mapper = createCustomCollectionPageMapper(collectionSlug || "");
+  items = paginatedItems.map(mapper);
+}
+
+export async function getStaticPaths() {
+  // Fetch all custom collection configs to generate static paths
+  try {
+    const data = await fetchCollection("custom-collections");
+    const configs = data?.docs || [];
+
+    // Also fetch all pages to exclude their slugs from matching this route
+    const { fetchCollection: fetchPages } = await import("@/utilities/fetch");
+    const pagesData = await fetchPages("pages");
+    const pageSlugs = new Set(
+      (pagesData?.docs || []).map((page: any) => page.slug),
+    );
+
+    // Only return paths for custom collections that aren't also page slugs
+    return configs
+      .filter((config: any) => !pageSlugs.has(config.slug))
+      .map((config: any) => ({
+        params: { collectionSlug: config.slug },
+      }));
+  } catch (error) {
+    console.warn(
+      "Could not generate static paths for custom collections:",
+      error,
+    );
+    return [];
+  }
+}
+
+export const prerender = import.meta.env.PREVIEW_MODE || false;
+---
+
+{
+  page ? (
+    <Layout title={page.title}>
+      <PageWithSideNav
+        heading={page.title}
+        showSideNav={true}
+        currentPath={`/${collectionSlug}`}
+        sideNavId={page.sideNavigation?.id}
+      >
+        {page.image && <Media media={page.image} />}
+        <RichText content={page.content} />
+      </PageWithSideNav>
+    </Layout>
+  ) : collectionConfig ? (
+    <Layout
+      title={collectionConfig.title}
+      currentPage={currentPage}
+      totalPages={totalPages}
+    >
+      <PagesSection heading={collectionConfig.title}>
+        {collectionConfig.description && (
+          <p class="margin-bottom-3">{collectionConfig.description}</p>
+        )}
+        <CollectionItemList items={items} />
+        {hasPaginationNav && (
+          <PaginationNav
+            currentPage={currentPage}
+            totalPages={totalPages}
+            basePath={`/${collectionSlug}/page`}
+          />
+        )}
+      </PagesSection>
+    </Layout>
+  ) : null
+}

--- a/src/pages/[collectionSlug]/page/[page].astro
+++ b/src/pages/[collectionSlug]/page/[page].astro
@@ -1,0 +1,112 @@
+---
+import CollectionItemList from "@/components/CollectionItemList.astro";
+import PagesSection from "@/components/PagesSection.astro";
+import Layout from "@/layouts/Layout.astro";
+import PaginationNav from "@/components/PaginationNav.astro";
+import {
+  fetchCustomCollectionPages,
+  createCustomCollectionPageMapper,
+  fetchCollection,
+  fetchSlug,
+} from "@/utilities/fetch";
+import { paginate } from "@/utilities/pagination";
+
+export const PAGE_SIZE = import.meta.env.PAGE_SIZE || 10;
+const { collectionSlug, page } = Astro.params;
+const currentPage = parseInt(page) || 1;
+
+// Check if this slug matches a custom collection config
+const collectionConfig = await fetchSlug(
+  "custom-collections",
+  collectionSlug || "",
+);
+
+if (!collectionConfig) {
+  return Astro.redirect("/404");
+}
+
+// Fetch pages for this custom collection
+const collectionPagesData = await fetchCustomCollectionPages(
+  collectionConfig.id,
+);
+const collectionPages = collectionPagesData?.docs || [];
+
+// Sort by publishedAt
+const sorted = collectionPages.sort((a: any, b: any) => {
+  return (
+    new Date(b.publishedAt || 0).getTime() -
+    new Date(a.publishedAt || 0).getTime()
+  );
+});
+
+// Paginate
+const hasPaginationNav = sorted.length >= PAGE_SIZE;
+const { totalPages, paginatedItems } = paginate(sorted, currentPage, PAGE_SIZE);
+
+// Map items
+const mapper = createCustomCollectionPageMapper(collectionSlug || "");
+const items = paginatedItems.map(mapper);
+
+export async function getStaticPaths() {
+  // Fetch all custom collection configs to generate static paths
+  try {
+    const data = await fetchCollection("custom-collections");
+    const configs = data?.docs || [];
+
+    const paths: any[] = [];
+
+    for (const config of configs) {
+      const pagesData = await fetchCollection(
+        `custom-collection-pages?where[collectionConfig][equals]=${config.id}&limit=0`,
+      );
+      const pages = pagesData?.docs || [];
+      const totalPages = pages.length;
+      const totalPagesCount = Math.ceil(totalPages / PAGE_SIZE);
+
+      // Generate paths for each page
+      for (let i = 1; i <= totalPagesCount; i++) {
+        paths.push({
+          params: {
+            collectionSlug: config.slug,
+            page: String(i),
+          },
+        });
+      }
+    }
+
+    return paths;
+  } catch (error) {
+    console.warn(
+      "Could not generate static paths for custom collection pagination:",
+      error,
+    );
+    return [];
+  }
+}
+
+export const prerender = import.meta.env.PREVIEW_MODE || false;
+---
+
+<Layout
+  title={collectionConfig.title}
+  currentPage={currentPage}
+  totalPages={totalPages}
+>
+  <PagesSection heading={collectionConfig.title}>
+    {
+      collectionConfig.description && (
+        <p class="margin-bottom-3">{collectionConfig.description}</p>
+      )
+    }
+    <CollectionItemList items={items} />
+    {
+      hasPaginationNav && (
+        <PaginationNav
+          currentPage={currentPage}
+          totalPages={totalPages}
+          basePath={`/${collectionSlug}/page`}
+        />
+      )
+    }
+  </PagesSection>
+</Layout>

--- a/src/utilities/fetch/index.ts
+++ b/src/utilities/fetch/index.ts
@@ -7,6 +7,8 @@ export {
   fetchCollection,
   fetchFooter,
   fetchPreFooter,
+  fetchCustomCollectionPages,
+  fetchCustomCollectionPageBySlug,
 } from "./queries";
 export { getPaginatedCollectionData } from "./collectionDataFetch";
 export {
@@ -25,6 +27,8 @@ export {
   reportMapper,
   leadershipMapper,
   resourceMapper,
+  customCollectionPageMapper,
+  createCustomCollectionPageMapper,
   alertsMapper,
   footerMapper,
 } from "./contentMapper";

--- a/src/utilities/fetch/queries.ts
+++ b/src/utilities/fetch/queries.ts
@@ -49,3 +49,23 @@ export async function fetchPageSlug(collectionName: string, slug: string) {
   );
   return processFetchResponse(await safeJsonParse(response));
 }
+
+// Custom Collections
+export async function fetchCustomCollectionPages(
+  collectionConfigId: string | number,
+) {
+  const response = await payloadFetch(
+    `custom-collection-pages?where[collectionConfig][equals]=${collectionConfigId}&limit=0`,
+  );
+  return await safeJsonParse(response);
+}
+
+export async function fetchCustomCollectionPageBySlug(
+  collectionConfigId: string | number,
+  pageSlug: string,
+) {
+  const response = await payloadFetch(
+    `custom-collection-pages?where[and][0][collectionConfig][equals]=${collectionConfigId}&where[and][1][slug][equals]=${pageSlug}&limit=1`,
+  );
+  return processFetchResponse(await safeJsonParse(response));
+}


### PR DESCRIPTION
## Changes proposed in this pull request:
- Added dynamic Astro routes under src/pages/[collectionSlug]/ so any custom collection (and its individual items/pagination) renders on its own slug, while gracefully falling back to regular pages (e.g., /about) when the slug matches a standard page.
- Introduced fetch helpers (collectionNames.ts, collectionSlug.ts, plus new exports in fetch/index.ts) to resolve display names, custom URL slugs, and the backing Payload collections at runtime.
- Registered customListsConfig and customListItems in content.config.ts and extended env.d.ts so the frontend knows about the new schema.
- Extended contentMapper.ts with customListItemMapper utilities, and wired them into new loaders/queries for fetching configs and items by slug.
- Updated navigation/pre-footer logic (e.g., Menu.astro, preFooterMapper.ts) to render links that point at user-defined custom collections.

## Things to check

- Make sure the new collections render correctly with various types of data

## Security considerations

None
