### PR TITLE
Chore update download file component

### DIFF
--- a/src/components/Media.astro
+++ b/src/components/Media.astro
@@ -3,7 +3,6 @@ import filePresent from "@uswds-images/usa-icons/file_present.svg";
 import {
   getMediaUrl,
   imageMimeTypes,
-  tag,
   formatMimeType,
   formatBytes,
 } from "@/utilities/media";

--- a/src/components/ResourceFile.astro
+++ b/src/components/ResourceFile.astro
@@ -1,0 +1,40 @@
+---
+import type { MediaValueProps } from "@/env";
+import { formatBytes, formatMimeType, getUploadUrl } from "@/utilities/media";
+
+interface Props {
+  resourceFiles: Array<{
+    file?: MediaValueProps;
+  }>;
+}
+
+const { resourceFiles } = Astro.props;
+
+const url = (file: MediaValueProps) => {
+  const url = getUploadUrl({
+    url: file.url,
+    filename: file.filename,
+    bucket: file.site.bucket,
+  });
+  return url;
+};
+---
+
+<h4>Resources</h4>
+{
+  resourceFiles.map((resourceFile) => (
+    <div>
+      <p>
+        <a
+          class="usa-link usa-link--external"
+          href={url(resourceFile.file)}
+          download={resourceFile.file.filename}
+        >
+          {resourceFile.file.altText || resourceFile.file.filename} [
+          {formatMimeType(resourceFile.file.mimeType)} -{" "}
+          {formatBytes(resourceFile.file.filesize)}]
+        </a>
+      </p>
+    </div>
+  ))
+}

--- a/src/components/RichTextConverters/upload.ts
+++ b/src/components/RichTextConverters/upload.ts
@@ -17,10 +17,6 @@ const upload = ({ node }: { node: SerializedUploadNode }): string => {
     bucket: value.site.bucket,
   });
 
-  const fileIcon = `
-    <img src="${filePresent.src}" width="${filePresent.width}" height="${filePresent.height}" alt="download file" />
-  `;
-
   const container = (slot) => `
     <div class="maxw-tablet">
       ${slot}
@@ -33,24 +29,10 @@ const upload = ({ node }: { node: SerializedUploadNode }): string => {
   }
 
   return container(`
-    <div class="usa-alert usa-alert--info usa-alert--slim usa-alert--no-icon">
-    <div class="usa-alert__body">
-      <h4 class="usa-alert__heading display-flex flex-row flex-align-center">
-        ${fileIcon} Download File
-      </h4>
-      <p class="usa-alert__text">
-        <a class="usa-link" href="${url}" download="true">
-          ${value.altText || value.filename}
-        </a>
-      </p>
-      <div class="usa-alert__text display-flex flex-column flex-align-end maxw-full">
-        <p class="usa-alert__text">
-          ${formatMimeType(value.mimeType)}
-          ${formatBytes(value.filesize)}
-        </p>
-      </div>
+    <div>
+      <p><a class="usa-link usa-link--external" href="${url}" download="${value.filename}">${value.altText || value.filename} [${formatMimeType(value.mimeType)} - ${formatBytes(value.filesize)}]</a>
     </div>
-  </div>`);
+  `);
 };
 
 export default upload;

--- a/src/pages/reports/[slug].astro
+++ b/src/pages/reports/[slug].astro
@@ -11,6 +11,7 @@ import PagesSection from "@/components/PagesSection.astro";
 import Tags from "@/components/Tags.astro";
 import Media from "@/components/Media.astro";
 import InPageNavigation from "@/components/InPageNavigation.astro";
+import ResourceFile from "@/components/ResourceFile.astro";
 
 const { slug } = Astro.params;
 const collectionName = "reports";
@@ -44,12 +45,24 @@ export const prerender = import.meta.env.PREVIEW_MODE || false;
       <h1 set:text={report.title} />
       {data.image && <Media media={data.image} />}
       <p class="font-sans-sm text-italic" set:text={report.date} />
-      <ul
-        class="usa-collection__meta display-flex"
-        aria-label="More information"
-      >
-        <Tags tags={report.tags} />
-      </ul>
+      {
+        data.reportFiles.length > 0 && (
+          <ResourceFile resourceFiles={data.reportFiles} />
+        )
+      }
+      {
+        report.tags && (
+          <>
+            <h4 class="margin-bottom-2">Tags</h4>
+            <ul
+              class="usa-collection__meta display-flex"
+              aria-label="More information"
+            >
+              <Tags tags={report.tags} />
+            </ul>
+          </>
+        )
+      }
     </div>
     <RichText content={report.content} />
     <Fragment slot="sidebar"></Fragment>

--- a/src/pages/resources/[slug].astro
+++ b/src/pages/resources/[slug].astro
@@ -11,6 +11,7 @@ import PagesSection from "@/components/PagesSection.astro";
 import Tags, { type Tag } from "@/components/Tags.astro";
 import InPageNavigation from "@/components/InPageNavigation.astro";
 import Media from "@/components/Media.astro";
+import ResourceFile from "@/components/ResourceFile.astro";
 
 const { slug } = Astro.params;
 const collectionName = "resources";
@@ -27,7 +28,6 @@ if (!Astro.isPrerendered) {
 export const getStaticPaths = createGetStaticPath("resources");
 
 const resource = resourceMapper(data);
-
 export const prerender = true;
 ---
 
@@ -44,12 +44,24 @@ export const prerender = true;
       <h1 set:text={resource.title} />
       {data.image && <Media media={data.image} />}
       <p class="font-sans-sm text-italic" set:text={resource.date} />
-      <ul
-        class="usa-collection__meta display-flex"
-        aria-label="More information"
-      >
-        <Tags tags={resource.tags} />
-      </ul>
+      {
+        data.reportFiles.length > 0 && (
+          <ResourceFile resourceFiles={data.reportFiles} />
+        )
+      }
+      {
+        resource.tags && (
+          <>
+            <h4 class="margin-bottom-2">Tags</h4>
+            <ul
+              class="usa-collection__meta display-flex"
+              aria-label="More information"
+            >
+              <Tags tags={resource.tags} />
+            </ul>
+          </>
+        )
+      }
     </div>
     <RichText content={resource.content} />
   </PagesSection>

--- a/src/utilities/media.ts
+++ b/src/utilities/media.ts
@@ -77,15 +77,13 @@ export const imageMimeTypes = [
   "image/heic-sequence",
 ];
 
-export const tag = (value: string) => `<span class="usa-tag">${value}</span>`;
-
 export const formatMimeType = (type: string): string => {
   const parts = type.split("/");
-  return tag(parts[parts.length - 1].toLowerCase());
+  return parts[parts.length - 1].toUpperCase();
 };
 
 export const formatBytes = (bytes: number): string => {
-  if (bytes <= 0) return tag("O Bytes");
+  if (bytes <= 0) return "O Bytes";
 
   const units = [
     { name: "GB", divisor: 1024 * 1024 * 1024 },
@@ -96,10 +94,10 @@ export const formatBytes = (bytes: number): string => {
   for (const unit of units) {
     if (bytes >= unit.divisor) {
       // Round to 1 decimal places and return with unit
-      return tag(`${(bytes / unit.divisor).toFixed(1)} ${unit.name}`);
+      return `${(bytes / unit.divisor).toFixed(1)} ${unit.name}`;
     }
   }
 
   // If less than 1 KB, return in bytes
-  return tag(`${bytes} Bytes`);
+  return `${bytes} Bytes`;
 };


### PR DESCRIPTION
Closes #149 
## Changes proposed in this pull request:

- Revises the upload converter html output to use new design in the [mockup](https://figma-gov.com/design/tWKFEpGEKNjVDB0iiXpZXm/Pages---WIAB?node-id=1829-7922&t=WvtH2R8MrfPgBGC7-1)
- Adds a ResourceFile component to include non-embedded download files
- Conditionally show the ResourceFile component in Resources and Reports slug template.

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

No security risks with this change.
