### PR TITLE
fix: Homepage card description to check string type

### DIFF
--- a/src/components/CardGrid.astro
+++ b/src/components/CardGrid.astro
@@ -41,7 +41,8 @@ const { title, cards } = Astro.props;
                 </header>
                 <div class="usa-card__body">
                   <p>
-                    {card.description.length > 300
+                    {typeof card.description === "string" &&
+                    card.description.length > 300
                       ? card.description.substring(0, 300) + "..."
                       : card.description}
                   </p>


### PR DESCRIPTION
## Changes proposed in this pull request:
- Adds check to Home Page card description to check it is a string type

## Security considerations

None