### PR TITLE
fix: Preview deployment image paths and static file serving

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,10 +15,10 @@ Both portion of the application can be run locally. They require a number of env
 npm run dev
 ```
 
-and the proxy runs with:
+and the proxy runs on port 3030 with:
 
 ```sh
-node oauth/index.js
+node --watch oauth/index.js
 ```
 
 ## Tests
@@ -46,7 +46,7 @@ This check is also used in CI to verify the code is formatted in a pull request 
 
 **Fetch Implementation Locations**
 - Site-wide queries for global collections (like site configuration, menu, footer, etc.) are implemented at Layout level (`src/pages/index.astro`, `src/layouts`).
-- Content collection queries (like news, posts, pages, etc.) are implemented at `src/pages` level: 
+- Content collection queries (like news, posts, pages, etc.) are implemented at `src/pages` level:
   * for collection in `src/pages/COLLECTION_NAME/page/index.astro`;
   * for collection item in `src/pages/COLLECTION_NAME/[slug].astro`.
 - Fetch functions are:

--- a/src/components/ConnectSection.astro
+++ b/src/components/ConnectSection.astro
@@ -63,37 +63,42 @@ const socialLinks: SocialLink[] | undefined =
 
           {socialLinks && (
             <div class="usa-footer__social-links grid-row grid-gap-1">
-              {socialLinks.map((sm) => (
-                <div class="grid-col-auto">
-                  <a
-                    href={sm.url}
-                    class="usa-social-link"
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    aria-label="{sm.platform} (opens in new tab)"
-                  >
-                    <Image
-                      src={
-                        sm.platform === SocialPlatform.FACEBOOK
-                          ? facebookImg
-                          : sm.platform === SocialPlatform.X
-                            ? xImg
-                            : sm.platform === SocialPlatform.INSTAGRAM
-                              ? instagramImg
-                              : sm.platform === SocialPlatform.YOUTUBE
-                                ? youtubeImg
-                                : sm.platform === SocialPlatform.RSS_FEED
-                                  ? rssFeedImg
-                                  : ""
-                      }
-                      class="usa-social-link__icon"
-                      alt={sm.url}
-                      loading="lazy"
-                      decoding="async"
-                    />
-                  </a>
-                </div>
-              ))}
+              {socialLinks.map((sm) => {
+                const iconSrc =
+                  sm.platform === SocialPlatform.FACEBOOK
+                    ? facebookImg
+                    : sm.platform === SocialPlatform.X
+                      ? xImg
+                      : sm.platform === SocialPlatform.INSTAGRAM
+                        ? instagramImg
+                        : sm.platform === SocialPlatform.YOUTUBE
+                          ? youtubeImg
+                          : sm.platform === SocialPlatform.RSS_FEED
+                            ? rssFeedImg
+                            : null;
+
+                return (
+                  iconSrc && (
+                    <div class="grid-col-auto">
+                      <a
+                        href={sm.url}
+                        class="usa-social-link"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        aria-label="{sm.platform} (opens in new tab)"
+                      >
+                        <Image
+                          src={iconSrc}
+                          class="usa-social-link__icon"
+                          alt={sm.url}
+                          loading="lazy"
+                          decoding="async"
+                        />
+                      </a>
+                    </div>
+                  )
+                );
+              })}
             </div>
           )}
         </nav>

--- a/src/utilities/media.ts
+++ b/src/utilities/media.ts
@@ -43,12 +43,13 @@ export const getUploadUrl = ({
   filename: string;
   bucket: string;
 }) => {
-  const isPreview = import.meta.env.PREVIEW_MODE === "true";
+  const isPreview =
+    import.meta.env.PREVIEW_MODE || import.meta.env.PREVIEW_MODE === "true";
   const isLocal = import.meta.env.LOCAL_DEV === "true";
   const assetPath = `/~assets/${filename}`;
 
   if (isPreview) {
-    return url;
+    return `${import.meta.env.EDITOR_APP_URL}${url}`;
   }
 
   if (isLocal) {


### PR DESCRIPTION
Closes #167 

## Changes proposed in this pull request:
- Append `EDITOR_APP_URL` to preview deployment's media upload url
- Allow the preview authentication server to proxy image assets

## Security considerations

None
