### PR TITLE
fix: card grid image layout display

### DIFF
--- a/src/components/RichText.astro
+++ b/src/components/RichText.astro
@@ -126,6 +126,7 @@ let rawHTML = convertLexicalToHTML({
         "usa-card--flag",
         "flex-1",
         "usa-card--media-right",
+        "cardgrid-component",
       ],
       h1: false,
       h2: ["usa-process-list__heading", "usa-accordion__heading"],
@@ -174,6 +175,36 @@ let rawHTML = convertLexicalToHTML({
   :global(.identifier-prose a:hover) :global(.identifier-prose a:visited) {
     font-weight: 700;
     color: var(--linkColor) !important;
+  }
+
+  :global(.cardgrid-component .usa-card__container) {
+    border-radius: 0;
+    border: none;
+    background-color: #e6e6e2;
+  }
+  @media (min-width: 40em) {
+    :global(.cardgrid-component.usa-card--flag .usa-card__media) {
+      width: 11rem;
+    }
+
+    :global(.cardgrid-component.usa-card--flag .usa-card__img) {
+      border-top-left-radius: 0;
+      border-bottom-left-radius: 0;
+    }
+
+    :global(.cardgrid-component.usa-card--flag .usa-card__header),
+    :global(.cardgrid-component.usa-card--flag .usa-card__body),
+    :global(.cardgrid-component.usa-card--flag .usa-card__footer) {
+      margin-left: 11rem;
+      padding-left: 1rem;
+    }
+
+    :global(.cardgrid-component.usa-card--flag .usa-card__header) {
+      padding-top: 1rem;
+    }
+    :global(.cardgrid-component.usa-card--flag .usa-card__body) {
+      padding-top: 0;
+    }
   }
 </style>
 

--- a/src/components/RichTextConverters/cardGrid.test.ts
+++ b/src/components/RichTextConverters/cardGrid.test.ts
@@ -114,7 +114,7 @@ describe("rich text embedded card grid block", () => {
     // Horizontal card should include the orientation modifier class
     // (Your converter uses 'usa-card--horizontal' when orientation is "horizontal")
     expect(result).toContain(
-      'class="tablet:grid-col usa-card usa-card--flag flex-1"',
+      'class="tablet:grid-col usa-card cardgrid-component usa-card--flag flex-1"',
     ); // <— update to exact class if needed
 
     // Vertical card still renders as a usa-card without the horizontal modifier

--- a/src/components/RichTextConverters/cardGrid.ts
+++ b/src/components/RichTextConverters/cardGrid.ts
@@ -1,11 +1,12 @@
+import { getMediaUrl } from "@/utilities/media";
+
 type Card = {
-  image?: {
-    altText: string;
-    url: string;
-  };
+  image?: any;
   title: string;
   description: string;
   orientation?: "vertical" | "horizontal" | "horizontal-right";
+  link?: string;
+  linkText?: string;
 };
 
 export const cardGridBlock = ({ node }: { node: any }): string => {
@@ -31,16 +32,25 @@ export const cardGridBlock = ({ node }: { node: any }): string => {
           <div class="usa-card__media">
             <div class="usa-card__img">
               <img
-                src="${card.image.url}"
-                alt="${card.image.altText}"
+                src="${getMediaUrl(card.image)}"
+                alt="${card.image.altText || card.title}"
               />
             </div>
           </div>
         `
             : "";
+
+          const linkHTML =
+            card.link && card.linkText
+              ? `
+              <div class="usa-card__footer">
+                <a href="${card.link}" class="usa-button">${card.linkText}</a>
+              </div>
+            `
+              : "";
           return `
         <div class="
-          tablet:grid-col usa-card
+          tablet:grid-col usa-card cardgrid-component 
           ${card.orientation === "horizontal" ? "usa-card--flag flex-1" : ""}
           ${card.orientation === "horizontal-right" ? "usa-card--flag flex-1 usa-card--media-right" : ""}
           ">
@@ -52,6 +62,7 @@ export const cardGridBlock = ({ node }: { node: any }): string => {
             <div class="usa-card__body">
               <p class="usa-card__description">${card.description}</p>
             </div>
+            ${linkHTML}
           </div>
         </div>
       `;


### PR DESCRIPTION
## Changes proposed in this pull request:

- uses correct useMediaUrl() function to pull in image asset
- adds style overrides specific to design:
  - horizontal card image width adjustment, card border & background, text padding
- add footer with link

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

None
