### PR TITLE
feat: Add image size capability

### DIFF
--- a/src/components/RichText.astro
+++ b/src/components/RichText.astro
@@ -11,6 +11,7 @@ import { table, tablerow, tablecell } from "./RichTextConverters/table";
 import { processListBlock } from "./RichTextConverters/processList";
 import { accordionBlock } from "./RichTextConverters/accordion";
 import { cardGridBlock } from "./RichTextConverters/cardGrid";
+import { imageBlock } from "./RichTextConverters/image";
 
 const { content, alert = false, identifier = undefined } = Astro.props;
 const { textColor, linkColor } = identifier ?? {};
@@ -74,6 +75,10 @@ const htmlConverters: HTMLConvertersFunction<NodeTypes> = ({
         cardGridBlock({
           node,
         }),
+      image: ({ node }) =>
+        imageBlock({
+          node,
+        }),
       // Add future blocks here:
       // otherBlockSlug: ({ node }) => renderOtherBlock(node, nestedConverters),
     },
@@ -127,6 +132,13 @@ let rawHTML = convertLexicalToHTML({
         "flex-1",
         "usa-card--media-right",
         "cardgrid-component",
+        "maxw-tablet",
+        "maxw-desktop",
+        "maxw-mobile-lg",
+        "maxw-mobile",
+        "width-full",
+        "margin-x-auto",
+        "margin-left-auto",
       ],
       h1: false,
       h2: ["usa-process-list__heading", "usa-accordion__heading"],
@@ -158,7 +170,7 @@ let rawHTML = convertLexicalToHTML({
       ol: ["class"],
       li: ["class"],
       button: ["class", "type", "aria-expanded", "aria-controls"],
-      div: ["id", "data-allow-multiple"],
+      div: ["id", "data-allow-multiple", "style", "class"],
     },
   })}
 />

--- a/src/components/RichTextConverters/image.ts
+++ b/src/components/RichTextConverters/image.ts
@@ -1,0 +1,100 @@
+import { getUploadUrl, imageMimeTypes } from "@/utilities/media";
+import type { MediaValueProps } from "@/env";
+
+export const imageBlock = ({ node }: { node: any }): string => {
+  const fields = node?.fields ?? node;
+  const image = fields?.image;
+
+  if (!image || typeof image !== "object") {
+    return "";
+  }
+
+  const imageValue = image as MediaValueProps;
+  const altText = fields?.altText || imageValue?.altText || "";
+  const width = fields?.width || "tablet";
+  const customWidth = fields?.customWidth;
+  const align = fields?.align || "left";
+
+  const url = getUploadUrl({
+    url: imageValue.url,
+    filename: imageValue.filename,
+    bucket: imageValue.site?.bucket,
+  });
+
+  const getContainerClass = () => {
+    const classes: string[] = [];
+
+    // Width class
+    switch (width) {
+      case "full":
+        classes.push("width-full");
+        break;
+      case "desktop":
+        classes.push("maxw-desktop");
+        break;
+      case "tablet":
+        classes.push("maxw-tablet");
+        break;
+      case "mobile":
+        classes.push("maxw-mobile-lg");
+        break;
+      case "mobile-sm":
+        classes.push("maxw-mobile");
+        break;
+      case "custom":
+        // No width class for custom, handled by style
+        break;
+      default:
+        classes.push("maxw-tablet");
+    }
+
+    // Alignment class (only apply if not full width)
+    if (width !== "full") {
+      switch (align) {
+        case "center":
+          classes.push("margin-x-auto");
+          break;
+        case "right":
+          classes.push("margin-left-auto");
+          break;
+        case "left":
+        default:
+          // Left is default, no class needed
+          break;
+      }
+    }
+
+    return classes.join(" ");
+  };
+
+  const getContainerStyle = () => {
+    const styles: string[] = [];
+
+    if (width === "custom" && customWidth) {
+      styles.push(`max-width: ${customWidth}`);
+    }
+
+    return styles.length > 0 ? styles.join("; ") : "";
+  };
+
+  const containerClass = getContainerClass();
+  const containerStyle = getContainerStyle();
+
+  // Build the opening div tag with class or style
+  let containerOpen: string;
+  if (containerClass && !containerStyle) {
+    containerOpen = `<div class="${containerClass}">`;
+  } else if (containerStyle) {
+    const classAttr = containerClass ? ` class="${containerClass}"` : "";
+    containerOpen = `<div ${classAttr} style="${containerStyle}">`;
+  } else {
+    // Fallback: if no class or style, still add a div (shouldn't happen with default 'tablet')
+    containerOpen = '<div class="maxw-tablet">';
+  }
+
+  if (imageMimeTypes.includes(imageValue.mimeType)) {
+    return `${containerOpen}<img src="${url}" alt="${altText}" /></div>`;
+  }
+
+  return "";
+};


### PR DESCRIPTION
## Changes proposed in this pull request:

Added Image block converter (src/components/RichTextConverters/image.ts)

- Converts Image block data to HTML with width and alignment classes
- Supports predefined widths (full, desktop, tablet, mobile, mobile-small) and custom widths via inline styles
- Applies USWDS alignment classes (margin-x-auto, margin-left-auto) based on selection

Integrated Image block into RichText component (src/components/RichText.astro)

- Registered imageBlock converter in the blocks mapping
- Added width and alignment classes to sanitizeHtml allowed classes list
- Added style and class attributes to allowed div attributes for custom widths

Added tests (src/components/RichText.test.ts)

- Test suite covering all width options, alignment options, custom widths, alt text handling, and edge cases
- Follows existing test patterns for accordion and process list blocks

## Security considerations

None