### PR TITLE
fix: horizontal card image ratio

### DIFF
--- a/src/components/RichText.astro
+++ b/src/components/RichText.astro
@@ -196,7 +196,7 @@ let rawHTML = convertLexicalToHTML({
   }
   @media (min-width: 40em) {
     :global(.cardgrid-component.usa-card--flag .usa-card__media) {
-      width: 11rem;
+      width: 25%;
     }
 
     :global(.cardgrid-component.usa-card--flag .usa-card__img) {
@@ -207,7 +207,7 @@ let rawHTML = convertLexicalToHTML({
     :global(.cardgrid-component.usa-card--flag .usa-card__header),
     :global(.cardgrid-component.usa-card--flag .usa-card__body),
     :global(.cardgrid-component.usa-card--flag .usa-card__footer) {
-      margin-left: 11rem;
+      margin-left: 25%;
       padding-left: 1rem;
     }
 


### PR DESCRIPTION
## Changes proposed in this pull request:

- Set the media div to 25% of the width in horizontal oriented cards

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

No security concerns
