### PR TITLE
feat: add an background image to homepage text blocks

### DIFF
--- a/src/components/RichText.astro
+++ b/src/components/RichText.astro
@@ -139,6 +139,7 @@ let rawHTML = convertLexicalToHTML({
         "width-full",
         "margin-x-auto",
         "margin-left-auto",
+        "text-center",
       ],
       h1: false,
       h2: ["usa-process-list__heading", "usa-accordion__heading"],
@@ -194,6 +195,11 @@ let rawHTML = convertLexicalToHTML({
     border: none;
     background-color: #e6e6e2;
   }
+
+  :global(.textblock-image-bg .text-center .usa-prose p) {
+    max-width: none;
+  }
+
   @media (min-width: 40em) {
     :global(.cardgrid-component.usa-card--flag .usa-card__media) {
       width: 25%;

--- a/src/components/TextBlockImageBg.astro
+++ b/src/components/TextBlockImageBg.astro
@@ -1,0 +1,50 @@
+---
+import { getMediaUrl } from "@/utilities/media";
+import RichText from "./RichText.astro";
+
+export interface Props {
+  title?: string;
+  content?: any;
+  bgImage?: any;
+}
+
+const { title, content, bgImage } = Astro.props;
+
+const backgroundImageUrl = bgImage ? getMediaUrl(bgImage) : null;
+---
+
+{
+  bgImage && (
+    <section
+      class="textblock-image-bg"
+      style={
+        backgroundImageUrl
+          ? `background-image: url('${backgroundImageUrl}'); background-size: cover; background-position: center;`
+          : ""
+      }
+    >
+      <div class="grid-container padding-top-5 padding-bottom-5">
+        <div>
+          {title && <h2 class="text-center">{title}</h2>}
+          {content && (
+            <div class="text-center">
+              <RichText content={content} />
+            </div>
+          )}
+        </div>
+      </div>
+    </section>
+  )
+}
+{
+  !bgImage && (
+    <section class="usa-section">
+      <div class="grid-container">
+        <div class="maxw-4xl">
+          {title && <h2 class="font-heading-xl margin-bottom-3">{title}</h2>}
+          {content && <RichText content={content} />}
+        </div>
+      </div>
+    </section>
+  )
+}

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -75,7 +75,7 @@ const footer: FooterModel = footerMapper(
 );
 
 interface Props {
-  title: string;
+  title?: string;
   description?: string;
   socialImage?: any;
   canonical?: string;
@@ -83,7 +83,7 @@ interface Props {
   currentPage?: number;
   totalPages?: number;
   useBreadcrumbTitle?: boolean;
-  filtersSlugMetaData: FiltersSlugMetaDataModel;
+  filtersSlugMetaData?: FiltersSlugMetaDataModel;
 }
 
 // TODO: Add meta title and description to site config

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -4,6 +4,7 @@ import Hero from "@/components/Hero.astro";
 import CardGrid from "@/components/CardGrid.astro";
 import RichText from "@/components/RichText.astro";
 import { fetchHomePage } from "@/utilities/fetch";
+import TextBlockImageBg from "@/components/TextBlockImageBg.astro";
 
 // Fetch home page data from Payload CMS
 
@@ -44,18 +45,11 @@ const contentBlocks = homePageData?.content || [];
 
         case "textBlock":
           return (
-            <section class="usa-section">
-              <div class="grid-container">
-                <div class="maxw-4xl">
-                  {block.title && (
-                    <h2 class="font-heading-xl margin-bottom-3">
-                      {block.title}
-                    </h2>
-                  )}
-                  {block.content && <RichText content={block.content} />}
-                </div>
-              </div>
-            </section>
+            <TextBlockImageBg
+              title={block.title}
+              content={block.content}
+              bgImage={block.bgImage}
+            />
           );
 
         default:

--- a/src/utilities/media.ts
+++ b/src/utilities/media.ts
@@ -43,10 +43,14 @@ export const getUploadUrl = ({
   filename: string;
   bucket: string;
 }) => {
+  const baseUrl = import.meta.env.LOCAL_DEV
+    ? "/"
+    : (import.meta.env.BASEURL || "") + "/";
+
   const isPreview =
     import.meta.env.PREVIEW_MODE || import.meta.env.PREVIEW_MODE === "true";
   const isLocal = import.meta.env.LOCAL_DEV === "true";
-  const assetPath = `/~assets/${filename}`;
+  const assetPath = `${baseUrl}~assets/${filename}`;
 
   if (isPreview) {
     return `${import.meta.env.EDITOR_APP_URL}${url}`;


### PR DESCRIPTION
Closes [#238](https://github.com/cloud-gov/pages-editor/issues/238)
## Changes proposed in this pull request:

- Using the optional background image field for Homepage text blocks, adds the uploaded image to the background.
- Constructs the markup for the text block similar to how the Hero is presented. 

<img width="1403" height="662" alt="Screenshot 2026-02-03 at 3 59 08 PM (2)" src="https://github.com/user-attachments/assets/79c23002-a02a-4073-a6f1-7101de31adc6" />


## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

No security concerns. 
