### PR TITLE
fix: apply node converters in table child elements

### DIFF
--- a/src/components/RichText.astro
+++ b/src/components/RichText.astro
@@ -4,43 +4,95 @@ import {
   type HTMLConvertersFunction,
 } from "@payloadcms/richtext-lexical/html";
 import type { DefaultNodeTypes } from "@payloadcms/richtext-lexical";
+
 import sanitizeHtml from "sanitize-html";
+
 import upload from "./RichTextConverters/upload";
-import { getTextContent } from "./RichTextConverters/helpers";
 import { table, tablerow, tablecell } from "./RichTextConverters/table";
+import { getTextContent } from "./RichTextConverters/helpers";
 import { processListBlock } from "./RichTextConverters/processList";
 import { accordionBlock } from "./RichTextConverters/accordion";
 import { cardGridBlock } from "./RichTextConverters/cardGrid";
 import { imageBlock } from "./RichTextConverters/image";
+import type { SerializedEditorState } from "node_modules/lexical/LexicalEditorState";
+import type { SerializedLexicalNode } from "node_modules/lexical/LexicalNode";
 
 const { content, alert = false, identifier = undefined } = Astro.props;
 const { textColor, linkColor } = identifier ?? {};
+
 type NodeTypes = DefaultNodeTypes;
 
+/**
+ * Construct a minimal, valid SerializedEditorState for a given children array.
+ */
+const makeEditorState = (children: any[] = []) =>
+  ({
+    root: {
+      type: "root",
+      version: 1,
+      format: "left", // <-- must be ElementFormatType
+      indent: 0,
+      direction: "ltr", // <-- must be "ltr" | "rtl"
+      textFormat: 0,
+      textStyle: "",
+      children,
+    },
+  }) satisfies SerializedEditorState<SerializedLexicalNode>;
+
+/**
+ * Factory to create a function that renders node.children using a converter set.
+ */
+const createRenderChildren =
+  (nestedConverters: HTMLConvertersFunction<NodeTypes>) =>
+  (children: any[] = []) =>
+    convertLexicalToHTML({
+      data: makeEditorState(children),
+      converters: nestedConverters,
+    });
+
+/**
+ * Main converter block
+ */
 const htmlConverters: HTMLConvertersFunction<NodeTypes> = ({
   defaultConverters,
 }) => {
-  /*
-   * Converters used inside each process item body (nested rich text)
-   * Used to convert nested rich text inside Process List items without
-   * re-invoking block converters (avoids recursion while preserving
-   * heading/table/upload rules).
+  /**
+   * Nested converter pipeline (used inside blocks/tables).
+   * Avoids infinite recursion by not re-invoking block converters,
+   * but keeps upload/table/heading rules.
    */
-  const nestedConverters: HTMLConvertersFunction<NodeTypes> = () => ({
-    ...defaultConverters,
-    upload: ({ node }) => upload({ node }),
-    heading: ({ node }) => {
-      const text = node.children?.map(getTextContent).join("") || "";
-      const id = text
-        .toLowerCase()
-        .replace(/\s+/g, "-")
-        .replace(/[^a-z0-9-]/g, "");
-      return `<${node.tag} id="${id}">${text}</${node.tag}>`;
-    },
-    table: ({ node }) => table({ node }),
-    tablerow: ({ node }) => tablerow({ node }),
-    tablecell: ({ node }) => tablecell({ node }),
-  });
+  const nestedConverters: HTMLConvertersFunction<NodeTypes> = () => {
+    // child renderer for nested content
+    const renderChildren = createRenderChildren(nestedConverters);
+
+    return {
+      ...defaultConverters,
+
+      upload: ({ node }) => upload({ node }),
+
+      /**
+       * Preserve inline formatting inside headings but still generate stable IDs.
+       * We derive the ID from the plain-text version, but render inner HTML via renderChildren.
+       */
+      heading: ({ node }) => {
+        const plain = node.children?.map(getTextContent).join("") ?? "";
+        const id = plain
+          .toLowerCase()
+          .replace(/\s+/g, "-")
+          .replace(/[^a-z0-9-]/g, "");
+        const inner = renderChildren(node.children);
+        return `<${node.tag} id="${id}">${inner}</${node.tag}>`;
+      },
+
+      // Critical: table converters receive renderChildren and delegate cell content to it.
+      table: ({ node }) => table({ node, renderChildren }),
+      tablerow: ({ node }) => tablerow({ node, renderChildren }),
+      tablecell: ({ node }) => tablecell({ node, renderChildren }),
+    };
+  };
+
+  // child renderer for the top-level pipeline
+  const renderChildren = createRenderChildren(nestedConverters);
 
   return {
     ...defaultConverters,
@@ -48,43 +100,36 @@ const htmlConverters: HTMLConvertersFunction<NodeTypes> = ({
     upload: ({ node }) => upload({ node }),
 
     heading: ({ node }) => {
-      const text = node.children?.map(getTextContent).join("") || "";
-      const id = text
+      const plain = node.children?.map(getTextContent).join("") ?? "";
+      const id = plain
         .toLowerCase()
         .replace(/\s+/g, "-")
         .replace(/[^a-z0-9-]/g, "");
-      return `<${node.tag} id="${id}">${text}</${node.tag}>`;
+      const inner = renderChildren(node.children);
+      return `<${node.tag} id="${id}">${inner}</${node.tag}>`;
     },
 
-    table: ({ node }) => table({ node }),
-    tablerow: ({ node }) => tablerow({ node }),
-    tablecell: ({ node }) => tablecell({ node }),
+    // Table converters wired to use renderChildren
+    table: ({ node }) => table({ node, renderChildren }),
+    tablerow: ({ node }) => tablerow({ node, renderChildren }),
+    tablecell: ({ node }) => tablecell({ node, renderChildren }),
 
+    // We pass nestedConverters to bodies with nested rich text
     blocks: {
       processList: ({ node }) =>
-        processListBlock({
-          node,
-          htmlConverters: nestedConverters, // reuse pipeline for nested body
-        }),
+        processListBlock({ node, htmlConverters: nestedConverters }),
+
       accordion: ({ node }) =>
-        accordionBlock({
-          node,
-          htmlConverters: nestedConverters,
-        }),
-      cardGrid: ({ node }) =>
-        cardGridBlock({
-          node,
-        }),
-      image: ({ node }) =>
-        imageBlock({
-          node,
-        }),
-      // Add future blocks here:
-      // otherBlockSlug: ({ node }) => renderOtherBlock(node, nestedConverters),
+        accordionBlock({ node, htmlConverters: nestedConverters }),
+
+      cardGrid: ({ node }) => cardGridBlock({ node }),
+
+      image: ({ node }) => imageBlock({ node }),
     },
   };
 };
 
+// Convert full incoming RichText JSON using the main converters.
 let rawHTML = convertLexicalToHTML({
   data: content,
   converters: htmlConverters,
@@ -92,7 +137,9 @@ let rawHTML = convertLexicalToHTML({
 ---
 
 <section
-  class={`usa-prose ${alert && "alert-prose margin-y-0"} ${identifier && "identifier-prose margin-y-0"}`}
+  class={`usa-prose ${alert && "alert-prose margin-y-0"} ${
+    identifier && "identifier-prose margin-y-0"
+  }`}
   style={`--textColor: var(${textColor}); --linkColor: var(${linkColor});`}
   set:html={sanitizeHtml(rawHTML, {
     allowedTags: sanitizeHtml.defaults.allowedTags.concat([
@@ -109,7 +156,8 @@ let rawHTML = convertLexicalToHTML({
     ]),
     allowedClasses: {
       a: ["usa-button"],
-      table: ["usa-table", "usa-table--striped"],
+      table: ["usa-table", "usa-table--striped", "table-centered"],
+
       div: [
         "grid-row",
         "grid-gap",
@@ -140,6 +188,7 @@ let rawHTML = convertLexicalToHTML({
         "margin-x-auto",
         "margin-left-auto",
         "text-center",
+        "usa-table-container--scrollable",
       ],
       h1: false,
       h2: ["usa-process-list__heading", "usa-accordion__heading"],
@@ -147,6 +196,7 @@ let rawHTML = convertLexicalToHTML({
       h4: ["usa-process-list__heading", "usa-accordion__heading"],
       h5: ["usa-process-list__heading", "usa-accordion__heading"],
       h6: ["usa-process-list__heading", "usa-accordion__heading"],
+
       img: false,
       li: ["usa-process-list__item"],
       ol: ["usa-process-list"],
@@ -160,13 +210,17 @@ let rawHTML = convertLexicalToHTML({
       img: ["src", "alt"],
       use: ["href"],
       svg: ["class", "aria-hidden", "focusable", "role", "img"],
+
       h1: ["id", "class"],
       h2: ["id", "class"],
       h3: ["id", "class"],
       h4: ["id", "class"],
       h5: ["id", "class"],
       h6: ["id", "class"],
-      th: ["scope"],
+
+      th: ["scope", "colspan", "rowspan"],
+      td: ["colspan", "rowspan"],
+
       table: ["class"],
       ol: ["class"],
       li: ["class"],
@@ -180,10 +234,12 @@ let rawHTML = convertLexicalToHTML({
   :global(.alert-prose p) {
     max-width: 100%;
   }
+
   :global(.identifier-prose p) {
     font-weight: 700;
     color: var(--textColor);
   }
+
   :global(.identifier-prose a),
   :global(.identifier-prose a:hover) :global(.identifier-prose a:visited) {
     font-weight: 700;
@@ -208,11 +264,11 @@ let rawHTML = convertLexicalToHTML({
     margin-top: 1rem;
     margin-bottom: 1rem;
   }
+
   @media (min-width: 40em) {
     :global(.cardgrid-component.usa-card--flag .usa-card__media) {
       width: 25%;
     }
-
     :global(.cardgrid-component.usa-card--flag .usa-card__img) {
       border-top-left-radius: 0;
       border-bottom-left-radius: 0;
@@ -255,6 +311,14 @@ let rawHTML = convertLexicalToHTML({
     :global(.cardgrid-component.usa-card--flag .usa-card__body) {
       padding-top: 0;
     }
+
+    :global(.usa-table-container--scrollable .usa-table.table-centered) {
+      margin: 0 auto;
+    }
+  }
+  // prevents paragraph elements from escaping table cell
+  :global(.usa-table-container--scrollable .usa-table p) {
+    max-width: none;
   }
 </style>
 

--- a/src/components/RichText.test.ts
+++ b/src/components/RichText.test.ts
@@ -56,12 +56,24 @@ describe("RichText", () => {
                       {
                         type: "tablecell",
                         headerState: 1,
-                        children: [{ text: "Header 1" }],
+                        children: [
+                          {
+                            type: "paragraph",
+                            children: [{ type: "text", text: "Header 1" }],
+                          },
+                        ],
                       },
                       {
                         type: "tablecell",
                         headerState: 1,
-                        children: [{ text: "Header 1" }],
+                        children: [
+                          {
+                            type: "paragraph",
+                            children: [
+                              { type: "text", text: "<h2>Header 2</h2>" },
+                            ],
+                          },
+                        ],
                       },
                     ],
                   },
@@ -71,12 +83,39 @@ describe("RichText", () => {
                       {
                         type: "tablecell",
                         headerState: 2,
-                        children: [{ text: "Row 1" }],
+                        children: [
+                          {
+                            type: "paragraph",
+                            children: [{ type: "text", text: "Row 1" }],
+                          },
+                          {
+                            type: "paragraph",
+                            children: [
+                              {
+                                type: "text",
+                                text: '<a href="http://gsa.gov">gsa.gov</a>',
+                              },
+                            ],
+                          },
+                        ],
                       },
                       {
                         type: "tablecell",
                         headerState: 0,
-                        children: [{ text: "Data 1" }],
+                        children: [
+                          {
+                            type: "upload",
+                            value: {
+                              altText: "image",
+                              site: {
+                                bucket: "pages-site-bucket",
+                              },
+                              mimeType: "image/png",
+                              url: "/api/media/file/logo.png",
+                              filename: "logo.png",
+                            },
+                          },
+                        ],
                       },
                     ],
                   },
@@ -92,7 +131,9 @@ describe("RichText", () => {
       });
 
       // Check for table classes
-      expect(result).toContain('<table class="usa-table usa-table--striped">');
+      expect(result).toContain(
+        '<table class="usa-table usa-table--striped table-centered">',
+      );
 
       // Check for thead and tbody
       expect(result).toContain("<thead>");
@@ -104,7 +145,9 @@ describe("RichText", () => {
 
       // Check for cell content
       expect(result).toContain("Header 1");
-      expect(result).toContain("Data 1");
+      expect(result).toContain("<h2>Header 2</h2>");
+      expect(result).toContain('<a href="http://gsa.gov">gsa.gov</a>');
+      expect(result).toContain('<img src="/~assets/logo.png" alt="image" />');
     });
   });
 });


### PR DESCRIPTION
Closes [2798](https://github.com/cloud-gov/private/issues/2798)
## Changes proposed in this pull request:

- image rendering in table cells
- text formatting in table cells
- link rendering in table cells

Changes refactor rich-text rendering so table cells preserve full markup and uploads. Replaces getTextContent that was flattening html elements in table cell converters with a new renderChildren function that applies Payload Lexical HTML flow for cell child nodes. Refactors to include <thead>/<tbody>. Adds makeEditorState to RichText.astro for a minimal editor state validator. Resulting in uploads, headings, bold/italic, lists, links now able to render correctly inside tables.

## Screenshots

<img width="1078" height="932" alt="Screenshot 2026-02-12 at 10 30 44 AM (2)" src="https://github.com/user-attachments/assets/b736d664-b452-4bfa-8399-c577070e6a0e" />

**desktop**
<img width="1306" height="951" alt="dt-scrollable" src="https://github.com/user-attachments/assets/72fe008a-89a0-4367-a467-d4f09eb52a55" />
**mobile**
<img width="720" height="852" alt="mob-scrollable-a" src="https://github.com/user-attachments/assets/80626795-108b-437c-9759-fdee24193f42" />
<img width="778" height="851" alt="mob-scrollable-b" src="https://github.com/user-attachments/assets/c8877b8d-6fd8-4f6a-af9a-7d5c18cc6235" />

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

No impacts to security. Refactors RichText converters.
