### PR TITLE
chore: refactor collection items and filtering

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,3 +9,4 @@ RENDER_MODE='server'
 PREVIEW_MODE=true
 LOCAL_DEV=true
 PAGE_SIZE=10
+USE_USWSDS_THEME=false # set to true to use original theme with primary and secondary color

--- a/src/components/CollectionItem.astro
+++ b/src/components/CollectionItem.astro
@@ -10,6 +10,7 @@ export interface Props {
   title: string;
   description?: string;
   date?: string | DateParts;
+  publishedAt?: string | DateParts;
   tags?: Tag[];
   media?: MediaValueProps;
   link?: string;
@@ -23,6 +24,7 @@ const {
   tags = [],
   media = null,
   link = "",
+  publishedAt = null,
 } = Astro.props;
 
 function normalizeDate(input?: string | DateParts): DateParts | null {
@@ -33,7 +35,7 @@ function normalizeDate(input?: string | DateParts): DateParts | null {
     : null;
 }
 
-const dateParts = normalizeDate(date);
+const dateParts = date ? normalizeDate(date) : normalizeDate(publishedAt);
 
 const hasTags = tags?.length > 0;
 const hasDescription = !!description?.trim();
@@ -60,13 +62,6 @@ const hasValidDate = !!(
         <Link href={link}>{title}</Link>
       </SectionHeader>
       {
-        hasDescription && (
-          <div class="usa-collection__description">
-            <p set:html={description.replace(/\n/g, "<br>")} />
-          </div>
-        )
-      }
-      {
         hasValidDate && (
           <ul class="usa-collection__meta" aria-label="More information">
             <li class="usa-collection__meta-item collection-item-date">
@@ -85,6 +80,13 @@ const hasValidDate = !!(
           >
             <Tags tags={tags} />
           </ul>
+        )
+      }
+      {
+        hasDescription && (
+          <div class="usa-collection__description">
+            <p set:html={description.replace(/\n/g, "<br>")} />
+          </div>
         )
       }
     </div>

--- a/src/components/CollectionItem.test.ts
+++ b/src/components/CollectionItem.test.ts
@@ -103,8 +103,8 @@ describe("CollectionItem", () => {
       title: "With Tags",
       link: "/tags",
       tags: [
-        { label: "News", url: "/?tag=news" },
-        { label: "UX", url: "/?tag=ux" },
+        { title: "News", url: "/?tag=news" },
+        { title: "UX", url: "/?tag=ux" },
       ],
     });
 

--- a/src/components/CollectionItemList.astro
+++ b/src/components/CollectionItemList.astro
@@ -2,18 +2,53 @@
 import CollectionItem from "@/components/CollectionItem.astro";
 import { COLLECTION_ITEM_LIST_ID } from "@/utilities/filter";
 
-const { items = [], showEvent = false, currentPage = 1 } = Astro.props;
+const {
+  items = [],
+  showEvent = false,
+  currentPage = 1,
+  filteredLength = 1,
+} = Astro.props;
+const PAGE_SIZE = import.meta.env.PAGE_SIZE ?? 10;
+const resultsRangeStart = (currentPage - 1) * PAGE_SIZE + 1;
+const resultsRangeEnd = Math.min(currentPage * PAGE_SIZE, filteredLength);
+const resultsCountText =
+  filteredLength > 0
+    ? `Showing ${resultsRangeStart}-${resultsRangeEnd} of ${filteredLength} results`
+    : null;
+const resultsCountTextSr =
+  filteredLength > 0
+    ? `Showing ${resultsRangeStart} to ${resultsRangeEnd} of ${filteredLength} results`
+    : null;
 ---
 
-<div>
-  {items.length === 0 && <p>No items found</p>}
-  {
-    items.length > 0 && (
-      <ul class="usa-collection measure-6" id={COLLECTION_ITEM_LIST_ID}>
-        {items.map((n) => (
-          <CollectionItem {...n} showEvent={showEvent} />
-        ))}
-      </ul>
-    )
-  }
-</div>
+<>
+  <p
+    class="font-sans-sm text-bold margin-top-0 margin-bottom-2"
+    aria-live="polite"
+    aria-atomic="true"
+    role="status"
+    id="pagination-status"
+  >
+    {
+      resultsCountText ? (
+        <>
+          <span aria-hidden="true">{resultsCountText}</span>
+          <span class="usa-sr-only">{resultsCountTextSr}</span>
+        </>
+      ) : (
+        "No results match the selected filters"
+      )
+    }
+  </p>
+  <div>
+    {
+      filteredLength > 0 && (
+        <ul class="usa-collection measure-6" id={COLLECTION_ITEM_LIST_ID}>
+          {items.map((n) => (
+            <CollectionItem {...n} showEvent={showEvent} />
+          ))}
+        </ul>
+      )
+    }
+  </div>
+</>

--- a/src/components/Filters.astro
+++ b/src/components/Filters.astro
@@ -24,13 +24,20 @@ const dataAttributes = getFiltersDataAttributes(
 );
 ---
 
-<aside class="sidenav-container">
-  {
-    dataAttributes && (
-      <span id={FILTERS_DATA_ID} {...dataAttributes} style="display:none" />
-    )
-  }
-  {FILTERS_CONFIG?.map((filter) => <Filter filter={filter} />)}
+<aside class="sidenav-container sidebar-layout__sidebar">
+  <div class="filter-sidebar">
+    <div class="filter-sidebar__header">
+      <h2 class="font-sans-lg">Filters</h2>
+    </div>
+    <div>
+      {
+        dataAttributes && (
+          <span id={FILTERS_DATA_ID} {...dataAttributes} style="display:none" />
+        )
+      }
+      {FILTERS_CONFIG?.map((filter) => <Filter filter={filter} />)}
+    </div>
+  </div>
 </aside>
 
 <script>
@@ -52,6 +59,7 @@ const dataAttributes = getFiltersDataAttributes(
     getFiltersSelections,
   } from "../utilities/filter";
   import { type ElementsPair, type FiltersData } from "../env.d";
+  import { updatePaginationStatus } from "@/utilities/filter/filtersRender";
 
   let collectionListPair: ElementsPair;
   let paginationPair: ElementsPair;
@@ -81,6 +89,7 @@ const dataAttributes = getFiltersDataAttributes(
             updateHistoryState(filtersSelections);
             if (!filtersSelections) {
               displayOriginals(collectionListPair, paginationPair);
+              updatePaginationStatus(data.totalItems, 1, data.pageSize);
             } else {
               await search(
                 pagefind,

--- a/src/components/FiltersSlugMetaData.test.ts
+++ b/src/components/FiltersSlugMetaData.test.ts
@@ -20,7 +20,7 @@ describe("FiltersConfig", () => {
   it("adds pagefind metadata", async () => {
     let collectionName = "events";
     let collectionItem = {
-      tags: [{ label: "GEOGRAPHY" }, { label: "HISTORY" }],
+      tags: [{ title: "GEOGRAPHY" }, { title: "HISTORY" }],
       yearTag: "2025",
       sortField: "2026-01-05T17:23:16.181Z",
     };

--- a/src/components/InPageNavigation.astro
+++ b/src/components/InPageNavigation.astro
@@ -17,7 +17,7 @@ const {
 {
   show && (
     <>
-      <aside
+      <div
         class="usa-in-page-nav"
         data-title-text={titleText}
         data-title-heading-level="h4"

--- a/src/components/PagesSection.astro
+++ b/src/components/PagesSection.astro
@@ -1,11 +1,6 @@
 ---
-import Filters from "./Filters.astro";
-interface Button {
-  label: string;
-  url: string;
-  variant?: string;
-}
 import type { FilteredPageConfig } from "@/env";
+import Filters from "./Filters.astro";
 
 interface Props {
   heading?: string;
@@ -50,11 +45,11 @@ const {
       </div>
     </div>
     <section class="grid-container usa-section">
-      <div class="grid-row">
-        <div class="sidebar-section grid-col-4">
+      <div class=`grid-row grid-gap ${filteredPageConfig && "sidebar-layout"}`>
+        <div class="sidebar-layout__sidebar">
           {
             filteredPageConfig && (
-              <div class="grid-row margin-left-1">
+              <div class="filter-sidebar">
                 <Filters filteredPageConfig={filteredPageConfig} />
               </div>
             )
@@ -63,7 +58,7 @@ const {
             <slot name="sidebar" />
           </div>
         </div>
-        <div class="main-section grid-col-8">
+        <div class="sidebar-layout__main">
           <div class="section__container">
             <div class="section__slot">
               <slot />

--- a/src/components/RelatedItems.astro
+++ b/src/components/RelatedItems.astro
@@ -1,15 +1,19 @@
 ---
-import CollectionItem from "@/components/CollectionItem.astro";
 import type { RelatedItem } from "@/utilities/fetch/contentMapper";
 import Media from "@/components/Media.astro";
 
 const { items = [] } = Astro.props;
+const baseUrl = import.meta.env.LOCAL_DEV
+  ? "/"
+  : (import.meta.env.BASEURL || "") + "/";
 ---
 
 {
   items.length > 0 && (
-    <section class="margin-top-6">
-      <h2 class="font-heading-lg margin-bottom-3">Related Items</h2>
+    <section class="related-links-sidebar">
+      <h2 class="font-sans-lg font-heading-lg margin-bottom-3">
+        Related Items
+      </h2>
       <ul class="usa-collection measure-6">
         {items.map((item: RelatedItem) => (
           <li class="usa-collection__item maxw-tablet">
@@ -22,14 +26,22 @@ const { items = [] } = Astro.props;
                   <a
                     href={item.link}
                     target="_blank"
-                    rel="noopener noreferrer"
+                    rel="noopener noreferrer font-sans"
                     class="usa-link usa-link--external"
                   >
                     {item.label}
                     <span class="usa-sr-only"> (opens in new tab)</span>
                   </a>
                 ) : (
-                  <a href={item.link} class="usa-link">
+                  <a
+                    href={
+                      baseUrl +
+                      item.collectionEntry?.collectionSlug +
+                      "/" +
+                      item.collectionEntry?.slug
+                    }
+                    class="usa-link font-sans"
+                  >
                     {item.label}
                   </a>
                 )}
@@ -39,19 +51,11 @@ const { items = [] } = Astro.props;
                   <p set:html={item.description.replace(/\n/g, "<br>")} />
                 </div>
               )}
-              {item.date && !item.externalLink && (
+              {item.collectionEntry?.publishedAt && !item.externalLink && (
                 <ul class="usa-collection__meta" aria-label="More information">
                   <li class="usa-collection__meta-item">
-                    <time
-                      datetime={
-                        typeof item.date === "string"
-                          ? item.date
-                          : item.date.raw.toISOString()
-                      }
-                    >
-                      {typeof item.date === "string"
-                        ? item.date
-                        : item.date.full}
+                    <time datetime={item.collectionEntry?.publishedAt}>
+                      {item.collectionEntry?.publishedAt}
                     </time>
                   </li>
                 </ul>

--- a/src/components/Tags.astro
+++ b/src/components/Tags.astro
@@ -3,7 +3,7 @@
 import Link from "@/components/Link.astro";
 
 export interface Tag {
-  label: string;
+  title: string;
   url?: string;
 }
 interface Props {
@@ -18,12 +18,16 @@ const { tags } = Astro.props;
     if (tag.url) {
       return (
         <li class="usa-collection__meta-item">
-          <span class="usa-tag">{tag.label}</span>
+          <span class="usa-tag">{tag.title}</span>
         </li>
       );
     }
 
-    return <span class="usa-tag">{tag.label}</span>;
+    return (
+      <li class="usa-collection__meta-item">
+        <span class="usa-tag">{tag.title}</span>
+      </li>
+    );
   })
 }
 

--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -44,7 +44,7 @@ export interface CollectionTagProps {
   breadcrumbs?: {
     doc?: CollectionTagProps | null;
     url?: string | null;
-    label?: string | null;
+    title?: string | null;
     id?: string | null;
   };
   updatedAt: string;
@@ -282,6 +282,7 @@ export interface FilteredPageConfig {
   collectionName?: string;
   pageSize?: number | string;
   currentPage?: number | string;
+  totalItems?: number;
 }
 
 export type PageNavItemType = "prev" | "next" | "overflow" | "page";
@@ -303,6 +304,7 @@ export interface FiltersData {
   pageSize: string;
   currentPage: string;
   collectionName: string;
+  totalItems: number;
 }
 
 export interface FilterConfig {
@@ -323,7 +325,7 @@ export interface FilterOption {
 }
 
 export interface Tag {
-  label: string;
+  title: string;
   url: string;
 }
 
@@ -363,6 +365,7 @@ export type CollectionEntry = {
   id: number | string;
   title: string;
   slug: string;
+  publishedAt?: string;
   collectionSlug?: string; // to be added
 };
 

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -227,25 +227,14 @@ const isHome = Astro.url.pathname === "/";
       totalPages={totalPages}
       breadcrumbTitle={useBreadcrumbTitle ? title : null}
     />
-    {
-      useInPageNav ? (
-        <div class="usa-in-page-nav-container">
-          <slot name="in-page-nav" />
-          <main id="main-content" class="used-in">
-            <slot />
-          </main>
-        </div>
-      ) : (
-        <main
-          id="main-content"
-          class:list={{
-            home: isHome,
-          }}
-        >
-          <slot />
-        </main>
-      )
-    }
+    <main
+      id="main-content"
+      class:list={{
+        home: isHome,
+      }}
+    >
+      <slot />
+    </main>
     <Footer footer={footer} />
     {
       siteConfig.dapAgencyCode && (

--- a/src/pages/[collectionSlug]/[slug].astro
+++ b/src/pages/[collectionSlug]/[slug].astro
@@ -3,6 +3,7 @@ import {
   fetchCustomCollectionEntryBySlug,
   createCustomCollectionEntryMapper,
   fetchSlug,
+  fetchCollectionEntry,
 } from "@/utilities/fetch";
 import { tryParseDateParts } from "@/utilities/dates";
 import PagesSection from "@/components/PagesSection.astro";
@@ -13,6 +14,11 @@ import Media from "@/components/Media.astro";
 import InPageNavigation from "@/components/InPageNavigation.astro";
 import PreviewReload from "@/components/PreviewReload.astro";
 import { fetchCollection } from "@/utilities/fetch";
+import RelatedItems from "@/components/RelatedItems.astro";
+import { buildRelatedItemsWithCollectionSlugs } from "@/utilities/fetch/buildRelatedItemsWithCollectionSlugs";
+import { getFiltersSlugMetaData } from "@/utilities/filter";
+import type { FiltersSlugMetaDataModel } from "@/env";
+import FiltersCollectionItemTemplate from "@/components/FiltersCollectionItemTemplate.astro";
 
 const { collectionSlug, slug: pageSlug } = Astro.params;
 
@@ -48,29 +54,28 @@ const contentDate = data.contentDate
   : null;
 
 export async function getStaticPaths() {
-  // Fetch all custom collection configs and their pages to generate static paths
   try {
     const configsData = await fetchCollection("collection-types");
-    const configs = configsData?.docs || [];
+    const configs = configsData?.docs ?? [];
 
-    const paths: any[] = [];
+    const paths = [];
 
     for (const config of configs) {
+      // fetch entries ONLY for this config
       const pagesData = await fetchCollection(
-        `collection-entries?where[collectionType][id][equals]=${config.id}&limit=0`,
+        `collection-entries?where[collectionType.slug][equals]=${config.slug}&limit=0`,
       );
-      const pages = pagesData?.docs || [];
+
+      const pages = pagesData?.docs ?? [];
 
       for (const page of pages) {
-        if (page.slug) {
-          paths.push({
-            params: {
-              collectionSlug: config.slug,
-              slug: page.slug,
-            },
-            props: { data: page, collectionConfig: config },
-          });
-        }
+        paths.push({
+          params: {
+            collectionSlug: config.slug,
+            slug: page.slug,
+          },
+          props: { data: page, collectionConfig: config },
+        });
       }
     }
 
@@ -83,102 +88,154 @@ export async function getStaticPaths() {
     return [];
   }
 }
-
+const relatedItems = await buildRelatedItemsWithCollectionSlugs(
+  data.relatedItems,
+  fetchCollectionEntry,
+);
 export const prerender = import.meta.env.PREVIEW_MODE || false;
+
+const filtersSlugMetaData: FiltersSlugMetaDataModel = getFiltersSlugMetaData(
+  collectionSlug,
+  item,
+  pageSlug,
+);
 ---
 
 <Layout
   title={item.title}
   useInPageNav={item.showInPageNav}
   useBreadcrumbTitle={true}
+  filtersSlugMetaData={filtersSlugMetaData}
 >
-  {
-    item.showInPageNav && (
-      <Fragment slot="in-page-nav">
-        <InPageNavigation />
-      </Fragment>
-    )
-  }
   <PagesSection heading={data.title}>
-    <div class="flex-column margin-bottom-5">
-      {data.image && <Media media={data.image} />}
-      {item.date && <p class="font-sans-sm text-italic" set:text={item.date} />}
-      {
-        data.tags && data.tags.length > 0 && (
-          <ul
-            class="usa-collection__meta display-flex margin-top-2"
-            aria-label="More information"
-          >
-            <Tags
-              tags={data.tags.map((cat) => ({
-                label: cat.title,
-                url: `/${collectionSlug}?tag=${cat.slug}`,
-              }))}
-            />
-          </ul>
-        )
-      }
-    </div>
-
-    {
-      contentDate && (
+    <article class="grid-container padding-top-0 usa-section">
+      <div class="grid-row grid-gap grid-gap-6">
+        {/* set colum width if related items are present */}
         <div
-          class="usa-summary-box maxw-tablet margin-bottom-2"
-          role="region"
-          aria-labelledby={`content-details-${data.slug}`}
+          class={data.relatedItems?.length > 0 || item.showInPageNav
+            ? "tablet:grid-col-9"
+            : "tablet:grid-col-12"}
         >
-          <div class="usa-summary-box__body">
-            <h2
-              class="usa-summary-box__heading"
-              id={`content-details-${data.slug}`}
-            >
-              Details
-            </h2>
-            <div class="usa-summary-box__text">
-              <ul class="usa-list">
-                {contentDate && (
-                  <li>
-                    <b>Date:</b> {contentDate.full}
-                  </li>
-                )}
-              </ul>
-            </div>
-          </div>
-        </div>
-      )
-    }
-
-    {data.excerpt && <p class="margin-bottom-2">{data.excerpt}</p>}
-
-    {
-      data.content && (
-        <section class="margin-top-4">
-          <RichText content={data?.content[0]?.content} />
-        </section>
-      )
-    }
-
-    {
-      data.files && data.files.length > 0 && (
-        <section class="margin-top-4">
-          <h3>Files</h3>
-          <ul class="usa-list">
-            {data.files.map((fileItem) => (
-              <li>
-                <a
-                  href={fileItem.file?.url}
-                  target="_blank"
-                  rel="noopener noreferrer"
+          {
+            data.image && (
+              <div class="entry-thumbnail margin-y-2">
+                <Media media={data.image} />
+              </div>
+            )
+          }
+          <div class="maxw-72 margin-bottom-4">
+            <p class="text-gray-50">
+              {
+                item.date && (
+                  <p class="font-sans-sm text-italic" set:text={item.date} />
+                )
+              }
+            </p>
+            {
+              /* possible deprecated feature */
+              contentDate && (
+                <div
+                  class="usa-summary-box maxw-tablet margin-bottom-2"
+                  role="region"
+                  aria-labelledby={`content-details-${data.slug}`}
                 >
-                  {fileItem.label || fileItem.file?.filename || "Download"}
-                </a>
-              </li>
-            ))}
-          </ul>
-        </section>
-      )
-    }
+                  <div class="usa-summary-box__body">
+                    <h2
+                      class="usa-summary-box__heading"
+                      id={`content-details-${data.slug}`}
+                    >
+                      Details
+                    </h2>
+                    <div class="usa-summary-box__text">
+                      <ul class="usa-list">
+                        {contentDate && (
+                          <li>
+                            <b>Date:</b> {contentDate.full}
+                          </li>
+                        )}
+                      </ul>
+                    </div>
+                  </div>
+                </div>
+              )
+            }
+
+            {
+              /* main content entry body */
+              data.content && (
+                <section class="margin-top-4">
+                  <RichText content={data?.content[0]?.content} />
+                </section>
+              )
+            }
+          </div>
+          <>
+            {
+              data.tags && data.tags.length > 0 && (
+                <ul
+                  class="usa-list usa-list--unstyled margin-top-4 content-tags"
+                  aria-label="More information"
+                >
+                  <Tags
+                    tags={data.tags.map((cat) => ({
+                      title: cat.title,
+                      url: `/${collectionSlug}?tag=${cat.slug}`,
+                    }))}
+                  />
+                </ul>
+              )
+            }
+          </>
+          <>
+            {
+              data.files && data.files.length > 0 && (
+                <section class="margin-top-4">
+                  <h3>Files</h3>
+                  <ul class="usa-list">
+                    {data.files.map((fileItem) => (
+                      <li>
+                        <a
+                          href={fileItem.file?.url}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                        >
+                          {fileItem.label ||
+                            fileItem.file?.filename ||
+                            "Download"}
+                        </a>
+                      </li>
+                    ))}
+                  </ul>
+                </section>
+              )
+            }
+          </>
+        </div>
+        {
+          (data.relatedItems.length > 0 || item.showInPageNav) && (
+            <aside
+              class="tablet:grid-col-3 related-links-sidebar"
+              aria-label="Related Items"
+            >
+              {item.showInPageNav && (
+                <Fragment slot="in-page-nav">
+                  <InPageNavigation />
+                </Fragment>
+              )}
+              {data.relatedItems.length > 0 && (
+                <RelatedItems items={relatedItems} />
+              )}
+            </aside>
+          )
+        }
+      </div>
+      <div class="flex-column margin-bottom-5"></div>
+    </article>
   </PagesSection>
 </Layout>
-
+<FiltersCollectionItemTemplate
+  item={item}
+  showEvent={false}
+  filtersSlugMetaData={filtersSlugMetaData}
+/>
 <PreviewReload />

--- a/src/pages/[collectionSlug]/index.astro
+++ b/src/pages/[collectionSlug]/index.astro
@@ -30,6 +30,7 @@ let items: any[] = [];
 let currentPage = 1;
 let totalPages = 1;
 let hasPaginationNav = false;
+let sorted = null;
 
 if (!collectionConfig) {
   // Check if this is a regular page - if so, render it here since this route matched first
@@ -45,7 +46,7 @@ if (!collectionConfig) {
   collectionPages = collectionPagesData?.docs || [];
 
   // Sort by publishedAt
-  const sorted = collectionPages.sort((a: any, b: any) => {
+  sorted = collectionPages.sort((a: any, b: any) => {
     return (
       new Date(b.publishedAt || 0).getTime() -
       new Date(a.publishedAt || 0).getTime()
@@ -58,40 +59,27 @@ if (!collectionConfig) {
   const paginationResult = paginate(sorted, currentPage, PAGE_SIZE);
   totalPages = paginationResult.totalPages;
   const paginatedItems = paginationResult.paginatedItems;
-
   // Map items
   const mapper = createCustomCollectionEntryMapper(collectionSlug || "");
   items = paginatedItems.map(mapper);
 }
 export async function getStaticPaths() {
-  // Fetch all custom collection configs to generate static paths
-  try {
-    const data = await fetchCollection("collection-types");
-    const configs = data?.docs || [];
+  const data = await fetchCollection("collection-types");
+  const configs = data?.docs ?? [];
 
-    // Also fetch all pages to exclude their slugs from matching this route
-    const { fetchCollection: fetchPages } = await import("@/utilities/fetch");
-    const pagesData = await fetchPages("pages");
-    const pageSlugs = new Set(
-      (pagesData?.docs || []).map((page: any) => page.slug),
-    );
-
-    // Only return paths for custom collections that aren't also page slugs
-    return configs
-      .filter((config: any) => !pageSlugs.has(config.slug))
-      .map((config: any) => ({
-        params: { collectionSlug: config.slug },
-      }));
-  } catch (error) {
-    console.warn(
-      "Could not generate static paths for custom collections:",
-      error,
-    );
-    return [];
-  }
+  return configs.map((config) => ({
+    params: { collectionSlug: config.slug },
+  }));
 }
 
-export const prerender = import.meta.env.PREVIEW_MODE || false;
+const filteredPageConfig = {
+  totalItems: collectionPages.length,
+  collectionName: collectionSlug,
+  pageSize: PAGE_SIZE,
+  currentPage: 1,
+};
+
+export const prerender = import.meta.env.PREVIEW_MODE ?? false;
 ---
 
 {
@@ -107,7 +95,7 @@ export const prerender = import.meta.env.PREVIEW_MODE || false;
         <RichText content={page?.content[0]?.content} />
       </PageWithSideNav>
     </Layout>
-  ) : collectionConfig ? (
+  ) : (
     <Layout
       title={collectionConfig.title}
       currentPage={currentPage}
@@ -116,8 +104,13 @@ export const prerender = import.meta.env.PREVIEW_MODE || false;
       <PagesSection
         heading={collectionConfig.title}
         subheading={collectionConfig.description}
+        filteredPageConfig={filteredPageConfig}
       >
-        <CollectionItemList items={items} />
+        <CollectionItemList
+          items={items}
+          currentPage="1"
+          filteredLength={sorted.length}
+        />
         {hasPaginationNav && (
           <PaginationNav
             currentPage={currentPage}
@@ -127,5 +120,5 @@ export const prerender = import.meta.env.PREVIEW_MODE || false;
         )}
       </PagesSection>
     </Layout>
-  ) : null
+  )
 }

--- a/src/pages/[collectionSlug]/page/[page].astro
+++ b/src/pages/[collectionSlug]/page/[page].astro
@@ -84,6 +84,11 @@ export async function getStaticPaths() {
 }
 
 export const prerender = import.meta.env.PREVIEW_MODE || false;
+const filteredPageConfig = {
+  collectionName: collectionSlug,
+  pageSize: PAGE_SIZE,
+  currentPage,
+};
 ---
 
 <Layout
@@ -94,8 +99,13 @@ export const prerender = import.meta.env.PREVIEW_MODE || false;
   <PagesSection
     heading={collectionConfig.title}
     subheading={collectionConfig.description}
+    filteredPageConfig={filteredPageConfig}
   >
-    <CollectionItemList items={items} />
+    <CollectionItemList
+      items={items}
+      currentPage={currentPage}
+      filteredLength={sorted.length}
+    />
     {
       hasPaginationNav && (
         <PaginationNav

--- a/src/pages/[slug].astro
+++ b/src/pages/[slug].astro
@@ -15,7 +15,7 @@ if (!page) return Astro.redirect("/404");
 
 export const getStaticPaths = createStaticPathsForPagesSlug();
 
-export const prerender = import.meta.env.PREVIEW_MODE || false;
+export const prerender = import.meta.env.PREVIEW_MODE ?? false;
 ---
 
 <Layout title={page.title} useBreadcrumbTitle={true}>
@@ -26,6 +26,6 @@ export const prerender = import.meta.env.PREVIEW_MODE || false;
     sideNavId={page.sideNavigation?.id}
   >
     {page.image && <Media media={page.image} />}
-    <RichText content={page.content} />
+    <RichText content={page?.content[0]?.content} />
   </PageWithSideNav>
 </Layout>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -2,7 +2,6 @@
 import Layout from "@/layouts/Layout.astro";
 import Hero from "@/components/Hero.astro";
 import CardGrid from "@/components/CardGrid.astro";
-import RichText from "@/components/RichText.astro";
 import { fetchHomePage } from "@/utilities/fetch";
 import TextBlockImageBg from "@/components/TextBlockImageBg.astro";
 

--- a/src/styles/custom/global.scss
+++ b/src/styles/custom/global.scss
@@ -64,6 +64,7 @@ code, kbd, pre, samp {
 p {
   font-family: var(--font-sans);
   line-height: 1.5;
+  max-width: none;
 }
 
 h1, h2, h3, h4, h5, h6 {
@@ -76,6 +77,7 @@ h3 { font-size: 1.5rem; }
 h4 { font-size: 1.25rem; }
 h5 { font-size: 0.9375rem; }
 h6 { font-size: 0.875rem; }
+
 
 [class*='usa-'] {
   font-family: var(--font-sans);
@@ -166,6 +168,14 @@ textarea {
 ul:not(.usa-nav__primary):not(.usa-nav__submenu):not(.usa-sidenav):not(.usa-sidenav__sublist):not(.usa-list):not(.usa-footer__primary-content):not(.usa-identifier__required-links-list) {
   padding-left: 0;
   margin: 0;
+}
+
+
+.usa-prose ul {
+  margin-bottom: 1em!important;
+  margin-top: 1em!important;
+  line-height: 1.6;
+  padding-left: 3ch!important;
 }
 
 #main-content {
@@ -1750,6 +1760,16 @@ footer.usa-footer .container,
   h2 {
     font-family: var(--font-serif);
   }
+
+  .usa-sidenav {
+    .usa-label {
+      border-top: 1px solid var(--color-ink);
+      padding: 1rem 0;
+      color: var(--color-ink);
+      font-weight: 700;
+    }
+    padding: 0 .5rem;
+  }
 }
 
 .filter-sidebar .usa-accordion {
@@ -1808,18 +1828,11 @@ footer.usa-footer .container,
 
 /* News & Events */
 .usa-collection {
-  .usa-collection__item {
-    &:first-child {
-      margin-top: 0;
-      padding-top: 0; 
-      border-top: none;
-    }
-  }
   .usa-collection__heading {
     font-family: var(--font-serif);
     font-size: 1.5rem;
 
-    a.usa-link {
+    a.usa-link:not(.font-sans) {
       font-family: var(--font-serif);
       &:focus:not(:focus-visible) {
         outline: none;
@@ -1878,6 +1891,10 @@ footer.usa-footer .container,
 .news-tags.content-tags .usa-tag {
   background-color: var(--color-gray-10);
   color: var(--color-ink);
+}
+
+.usa-in-page-nav {
+  margin-left: 0;
 }
 
 /* Hero: image background, callout on left — min-height and flex only on home */
@@ -2423,7 +2440,8 @@ footer.usa-footer .container,
 }
 
 .usa-collection {
-  .usa-collection__item:first-child {
+  > .usa-collection__item:first-child,
+  > div:first-child > .usa-collection__item {
     margin-top: 0;
     padding-top: 0;
     border-top: none;

--- a/src/utilities/fetch/buildRelatedItemsWithCollectionSlugs.ts
+++ b/src/utilities/fetch/buildRelatedItemsWithCollectionSlugs.ts
@@ -1,0 +1,85 @@
+import type { FetchResult } from "@/env";
+
+export interface RelatedItem {
+  id: string;
+  label: string;
+  collectionEntry: {
+    id: number | string;
+    slug: string;
+    title: string;
+    collectionSlug?: string;
+    publishedAt?: string;
+  };
+  blockType: string;
+  [key: string]: any;
+}
+
+export async function buildRelatedItemsWithCollectionSlugs(
+  relatedItems: RelatedItem[],
+  fetchCollectionEntry: (id: string | number) => Promise<FetchResult>,
+): Promise<RelatedItem[]> {
+  const cache = new Map<
+    string | number,
+    Promise<{ slug: string | null; publishedAt: string | null }>
+  >();
+
+  const getCollectionEnriched = (
+    id: string | number,
+  ): Promise<{
+    slug: string | null;
+    publishedAt: string | null;
+  }> => {
+    if (!cache.has(id)) {
+      const p = (async () => {
+        try {
+          const res = await fetchCollectionEntry(id);
+          const doc = res?.docs?.[0];
+
+          const publishedAt = doc?.publishedAt ?? null;
+
+          const publishedAtFormatted =
+            publishedAt !== null
+              ? new Date(publishedAt).toLocaleDateString("en-US", {
+                  year: "numeric",
+                  month: "long",
+                  day: "numeric",
+                })
+              : null;
+
+          return {
+            slug: doc?.collectionType?.slug ?? null,
+            publishedAt: publishedAtFormatted,
+          };
+        } catch (err) {
+          console.error(`Failed to fetch collectionEntry for id=${id}`, err);
+          return { slug: null, publishedAt: null };
+        }
+      })();
+
+      cache.set(id, p);
+    }
+
+    return cache.get(id)!;
+  };
+
+  return Promise.all(
+    relatedItems.map(async (item) => {
+      if (
+        item.blockType === "collectionEntryLink" &&
+        item.collectionEntry?.id != null
+      ) {
+        const enriched = await getCollectionEnriched(item.collectionEntry.id);
+
+        return {
+          ...item,
+          collectionEntry: {
+            ...item.collectionEntry,
+            collectionSlug: enriched.slug ?? undefined,
+            publishedAt: enriched.publishedAt ?? undefined,
+          },
+        };
+      }
+      return item;
+    }),
+  );
+}

--- a/src/utilities/fetch/contentMapper.ts
+++ b/src/utilities/fetch/contentMapper.ts
@@ -2,6 +2,7 @@ import { formatDate } from "../formatting";
 import { type DateParts, getYearTag, parseDateParts } from "../dates";
 import {
   type AlertModel,
+  type CollectionEntry,
   type CollectionTagProps,
   type FooterModel,
   type LinkModel,
@@ -38,7 +39,7 @@ export function filteredContentMapper(data, baseUrl, yearTag) {
   return {
     tags: (data.tags ?? []).map(
       (c): Tag => ({
-        label: c.title,
+        title: c.title,
         url: `${baseUrl}?tag=${c.slug}`,
       }),
     ),
@@ -59,7 +60,7 @@ export function contentMapper(
     date: dateConversionFunction(data[dateField] || data.publishedAt || ""),
     startDate: safeParse(data.startDate || ""),
     endDate: safeParse(endSrc),
-    description: data.excerpt || "",
+    description: data.description || "",
     media: data.image,
     imageAlt: data.image?.altText || data.title,
     link: `${baseUrl}/${data.slug}`,
@@ -222,7 +223,8 @@ export function footerMapper(i: any, pf: any): FooterModel {
 export interface RelatedItem {
   label: string;
   description?: string;
-  link: string;
+  link?: string;
+  collectionEntry?: CollectionEntry;
   externalLink: boolean;
   media?: MediaValueProps;
   date?: DateParts | string;

--- a/src/utilities/filter/filtersConfig.ts
+++ b/src/utilities/filter/filtersConfig.ts
@@ -4,8 +4,8 @@ export const FILTER_NAME_TAG = "tag";
 export const FILTER_NAME_YEAR = "year";
 
 export const FILTERS_CONFIG: FilterConfig[] = [
-  { filterName: FILTER_NAME_TAG, filterLabel: "Filter by document type" },
-  { filterName: FILTER_NAME_YEAR, filterLabel: "Filter by year" },
+  { filterName: FILTER_NAME_TAG, filterLabel: "Tags" },
+  { filterName: FILTER_NAME_YEAR, filterLabel: "Year" },
 ];
 
 export const FILTERS_DATA_ID = "pagefind-data";
@@ -23,4 +23,5 @@ export const DATASET_KEYS = {
   PAGE_SIZE: "pagesize",
   CURRENT_PAGE: "currentpage",
   COLLECTION_NAME: "collectionname",
+  TOTAL_ITEMS: "totalitems",
 } as const;

--- a/src/utilities/filter/filtersData.test.ts
+++ b/src/utilities/filter/filtersData.test.ts
@@ -15,7 +15,7 @@ describe("Filters Utility, getFiltersSlugMetaData", () => {
   it("creates filters metadata for a slug", () => {
     let collectionName: string;
     let collectionItem: {
-      tags: { label: string }[];
+      tags: { title: string }[];
       yearTag: string | number;
       sortField: string;
     };
@@ -55,7 +55,7 @@ describe("Filters Utility, getFiltersSlugMetaData", () => {
 
     collectionName = "events";
     collectionItem = {
-      tags: [{ label: "GEOGRAPHY" }],
+      tags: [{ title: "GEOGRAPHY" }],
       yearTag: "2025",
       sortField: "2025",
     };
@@ -79,7 +79,7 @@ describe("Filters Utility, getFiltersSlugMetaData", () => {
 
     collectionName = "events";
     collectionItem = {
-      tags: [{ label: "GEOGRAPHY" }, { label: "HISTORY" }],
+      tags: [{ title: "GEOGRAPHY" }, { title: "HISTORY" }],
       yearTag: "2025",
       sortField: "2025",
     };
@@ -135,6 +135,7 @@ describe("Filters Utility, getFiltersDataAttributes", () => {
       "data-baseurl": null,
       "data-currentpage": "1",
       "data-pagesize": "10",
+      "data-totalitems": 0,
     });
 
     filtersConfig = FILTERS_CONFIG;
@@ -153,6 +154,7 @@ describe("Filters Utility, getFiltersDataAttributes", () => {
       "data-pagefindfiltertag": "events_tag",
       "data-pagefindfilteryear": "events_year",
       "data-pagesize": "10",
+      "data-totalitems": 0,
     });
   });
 
@@ -182,6 +184,7 @@ describe("Filters Utility, getElementFiltersData", () => {
       pagesize: "2",
       currentpage: "1",
       baseurl: "/",
+      totalitems: "11",
     };
 
     expect(getElementFiltersData(dataset)).toEqual({
@@ -205,6 +208,7 @@ describe("Filters Utility, getElementFiltersData", () => {
         ],
       ]),
       pageSize: "2",
+      totalItems: 11,
     });
   });
 });

--- a/src/utilities/filter/filtersData.ts
+++ b/src/utilities/filter/filtersData.ts
@@ -24,11 +24,11 @@ export function getFiltersSlugMetaData(
   if (!collectionName || !collectionItem || !slug) return null;
 
   const tags: FilterAttribute[] = collectionItem?.tags
-    ?.filter((tag: Tag) => tag?.label)
+    ?.filter((tag: Tag) => tag?.title)
     .map((tag: Tag) => {
       return {
         attributeValue: `${getPagefindFilterName(collectionName, FILTER_NAME_TAG)}[content]`,
-        content: tag?.label?.toUpperCase(),
+        content: tag?.title?.toUpperCase(),
       };
     });
 
@@ -73,6 +73,9 @@ export function getFiltersDataAttributes(
   dataAttributes[`data-${DATASET_KEYS.COLLECTION_NAME}`] =
     filteredPageConfig.collectionName;
 
+  dataAttributes[`data-${DATASET_KEYS.TOTAL_ITEMS}`] = Number(
+    filteredPageConfig?.totalItems ?? 0,
+  );
   return dataAttributes;
 }
 
@@ -104,6 +107,7 @@ export function getElementFiltersData(dataset: DOMStringMap): FiltersData {
     pageSize: dataset[DATASET_KEYS.PAGE_SIZE],
     currentPage: dataset[DATASET_KEYS.CURRENT_PAGE],
     collectionName: dataset[DATASET_KEYS.COLLECTION_NAME],
+    totalItems: Number(dataset[DATASET_KEYS.TOTAL_ITEMS]),
   };
 }
 

--- a/src/utilities/filter/filtersRender.test.ts
+++ b/src/utilities/filter/filtersRender.test.ts
@@ -412,6 +412,53 @@ describe("Filters Render Utility, renderResults", () => {
     expect(pagination.filtered.childNodes.length).toBe(3);
   });
 
+  it("renders correct pagination status", async () => {
+    vi.restoreAllMocks();
+    // Arrange
+    document.body.innerHTML = `
+    <p id="pagination-status"></p>
+  `;
+
+    const collection = createElementsPair();
+    const pagination = createElementsPair();
+
+    const results = Array.from({ length: 24 }, (_, i) => ({ id: i + 1 }));
+    const filtersData = { currentPage: 2, pageSize: 10 } as any;
+
+    // Mock fragments as usual
+    vi.spyOn(searchModule, "getFilteredResultFragment").mockResolvedValue(
+      fragmentWithChildren(2),
+    );
+
+    vi.spyOn(paginationModule, "getFilteredPaginationFragment").mockReturnValue(
+      fragmentWithChildren(3),
+    );
+
+    // Act
+    renderResults(results, collection, pagination, filtersData);
+    await Promise.resolve(); // allow async render pipeline to complete
+
+    // Assert pagination status element exists
+    const statusEl = document.getElementById("pagination-status");
+    expect(statusEl).not.toBeNull();
+
+    // Compute expected text for currentPage=2, pageSize=10, total=24
+    const expectedVisible = "Showing 11-20 of 24 results";
+    const expectedSr = "Showing 11 to 20 of 24 results";
+
+    expect(statusEl!.innerHTML).toContain(expectedVisible);
+    expect(statusEl!.innerHTML).toContain(expectedSr);
+
+    // Assert the two-span structure
+    expect(statusEl!.querySelector('[aria-hidden="true"]')?.textContent).toBe(
+      expectedVisible,
+    );
+
+    expect(statusEl!.querySelector(".usa-sr-only")?.textContent).toBe(
+      expectedSr,
+    );
+  });
+
   it("hides pagination when pagination fragment is empty", async () => {
     const collection = createElementsPair();
     const pagination = createElementsPair();

--- a/src/utilities/filter/filtersRender.ts
+++ b/src/utilities/filter/filtersRender.ts
@@ -122,6 +122,12 @@ export async function renderResults(
   );
   if (filteredResultsFragment) {
     displayFiltered(collectionList, filteredResultsFragment);
+    // added update for pagination status
+    updatePaginationStatus(
+      results?.length,
+      filtersData.currentPage,
+      filtersData.pageSize,
+    );
   }
 
   const paginationFragment = getFilteredPaginationFragment(
@@ -168,6 +174,36 @@ export function hideBoth(elementsPair: ElementsPair) {
   }
 }
 
+export function updatePaginationStatus(
+  resultSize: number,
+  currentPage: number | string,
+  pageSize: number | string,
+) {
+  // get element by id: pagination-status
+  // assemble updated status text
+  const statusEl = document.getElementById("pagination-status");
+  if (!statusEl) return;
+
+  const page = Number(currentPage);
+  const size = Number(pageSize);
+  const total = Number(resultSize);
+
+  if (!total || total <= 0) {
+    statusEl.innerHTML = "";
+    return;
+  }
+  const resultsRangeStart = (page - 1) * size + 1;
+  const resultsRangeEnd = Math.min(page * size, total);
+
+  const resultsCountText = `Showing ${resultsRangeStart}-${resultsRangeEnd} of ${total} results`;
+  const resultsCountTextSr = `Showing ${resultsRangeStart} to ${resultsRangeEnd} of ${total} results`;
+
+  statusEl.innerHTML = `
+    <span aria-hidden="true">${resultsCountText}</span>
+    <span class="usa-sr-only">${resultsCountTextSr}</span>
+  `;
+}
+
 function getElementByName(filter: string): HTMLElement {
   const targetElement: NodeListOf<HTMLElement> =
     document.getElementsByName(filter);
@@ -190,7 +226,8 @@ export function getFirstPageLinkUrl() {
   if (!link || link.tagName !== "A") {
     return null;
   }
-  return link.href;
+  const linkHref = (link as HTMLAnchorElement).href;
+  return linkHref;
 }
 
 export function navigateToTheFirstPage(


### PR DESCRIPTION
Closes https://github.com/cloud-gov/private/issues/2863

## Changes proposed in this pull request:

- Reorder date and description in collections item card
- Adds results counting to collection list view
- Incorporates the pagefind based Filter Sidebar component to collection list view to filter view
- Updates the Related Items component to correctly add parent collection type slug
- Makes changes to markup & classes, css rules.

## Screenshots

<img width="1394" height="875" alt="Screenshot 2026-03-27 at 8 16 01 AM (2)" src="https://github.com/user-attachments/assets/e357be33-e80f-4eb7-b8fb-980867923446" />

<img width="1310" height="897" alt="Screenshot 2026-03-27 at 8 20 18 AM (2)" src="https://github.com/user-attachments/assets/f906f726-d7e9-4343-a81a-38460b71cd52" />

<img width="1393" height="895" alt="Screenshot 2026-03-27 at 8 16 10 AM (2)" src="https://github.com/user-attachments/assets/e2dbb226-799b-475d-9076-476190ef7e19" />

<img width="1388" height="889" alt="Screenshot 2026-03-27 at 8 19 42 AM (2)" src="https://github.com/user-attachments/assets/f64ce770-027c-4ec0-ad54-10878e2c1686" />

<img width="1243" height="887" alt="Screenshot 2026-03-27 at 8 19 52 AM (2)" src="https://github.com/user-attachments/assets/d73d8658-d67a-46b2-ac75-0ac3fa6a16d2" />


## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

No
