### PR TITLE
feat: add card grid layout to collection list

### DIFF
--- a/src/components/CardGrid.astro
+++ b/src/components/CardGrid.astro
@@ -71,7 +71,6 @@ const { title, cards } = Astro.props;
   }
 
   .grid-row > div {
-    flex: 0 0 calc(33.333% - 1rem);
     padding: 0 !important;
   }
 

--- a/src/components/CollectionItem.astro
+++ b/src/components/CollectionItem.astro
@@ -15,6 +15,9 @@ export interface Props {
   media?: MediaValueProps;
   link?: string;
   linkText?: string;
+  itemType?: "list" | "grid";
+  collectionSlug?: string;
+  showEvent?: boolean;
 }
 
 const {
@@ -25,9 +28,11 @@ const {
   media = null,
   link = "",
   publishedAt = null,
+  itemType = null,
+  collectionSlug = null,
 } = Astro.props;
 
-function normalizeDate(input?: string | DateParts): DateParts | null {
+function normalizeDate(input?: string | DateParts | null): DateParts | null {
   return input
     ? typeof input === "string"
       ? parseDateParts(input)
@@ -47,22 +52,55 @@ const hasValidDate = !!(
 );
 ---
 
-<>
-  <li class="usa-collection__item maxw-tablet">
-    {
-      media?.thumbnailURL && (
+{
+  itemType === "grid" ? (
+    <div class="tablet:grid-col-6 desktop:grid-col-4">
+      <div class="usa-card display-block text-no-underline resource-card-link resource-card-link--bordered">
+        <div class="usa-card__container">
+          <header class="usa-card__header">
+            <h3 class="usa-card__heading">{title}</h3>
+            <div class="resource-date margin-top-1">
+              {hasValidDate && (
+                <time datetime={dateParts.raw.toISOString()}>
+                  {dateParts.full}
+                </time>
+              )}
+            </div>
+          </header>
+          <div class="usa-card__body">
+            {description && <p>{description}</p>}
+            <div class="margin-top-2 content-tags">
+              {hasTags && (
+                <ul
+                  class="usa-collection__meta display-flex flex-wrap margin-top-2 collection-item-tags"
+                  aria-label="Tag links"
+                >
+                  <Tags tags={tags} />
+                </ul>
+              )}
+            </div>
+          </div>
+          <div class="usa-card__footer">
+            <span class="usa-link usa-link--external font-sans-sm">
+              <Link href={link}>View {collectionSlug} item</Link>
+            </span>
+          </div>
+        </div>
+      </div>
+    </div>
+  ) : (
+    <li class="usa-collection__item maxw-tablet">
+      {media?.thumbnailURL && (
         <Media className="usa-collection__img" media={media} />
-      )
-    }
-    <div class="usa-collection__body">
-      <SectionHeader
-        headingLevel="h2"
-        class="usa-collection__heading font-body-lg"
-      >
-        <Link href={link}>{title}</Link>
-      </SectionHeader>
-      {
-        hasValidDate && (
+      )}
+      <div class="usa-collection__body">
+        <SectionHeader
+          headingLevel="h2"
+          class="usa-collection__heading font-body-lg"
+        >
+          <Link href={link}>{title}</Link>
+        </SectionHeader>
+        {hasValidDate && (
           <ul class="usa-collection__meta" aria-label="More information">
             <li class="usa-collection__meta-item collection-item-date">
               <time datetime={dateParts.raw.toISOString()}>
@@ -70,28 +108,24 @@ const hasValidDate = !!(
               </time>
             </li>
           </ul>
-        )
-      }
-      {
-        hasTags && (
+        )}
+        {hasTags && (
           <ul
             class="usa-collection__meta display-flex margin-top-2 collection-item-tags"
             aria-label="Tag links"
           >
             <Tags tags={tags} />
           </ul>
-        )
-      }
-      {
-        hasDescription && (
+        )}
+        {hasDescription && (
           <div class="usa-collection__description">
             <p set:html={description.replace(/\n/g, "<br>")} />
           </div>
-        )
-      }
-    </div>
-  </li>
-</>
+        )}
+      </div>
+    </li>
+  )
+}
 
 <style is:global>
   .usa-collection__footer {

--- a/src/components/CollectionItem.test.ts
+++ b/src/components/CollectionItem.test.ts
@@ -31,6 +31,7 @@ describe("CollectionItem", () => {
     expect(html).toContain("Test Report");
     expect(html).toContain("A report summary");
     expect(html).toContain('href="/test"');
+    expect(html).toContain("usa-collection__item");
   });
 
   it("hides description when omitted", async () => {
@@ -133,5 +134,16 @@ describe("CollectionItem", () => {
     expect(html).toContain("Bare minimum");
     expect(html).toContain('href="/bare"');
     expect(html).not.toContain("<img");
+  });
+
+  it("renders as a card grid", async () => {
+    const html = await renderHTML({
+      title: "Card",
+      link: "/card",
+      itemType: "grid",
+    });
+
+    expect(html).toContain("usa-card");
+    expect(html).not.toContain("usa-collection__item");
   });
 });

--- a/src/components/CollectionItemList.astro
+++ b/src/components/CollectionItemList.astro
@@ -1,13 +1,32 @@
 ---
 import CollectionItem from "@/components/CollectionItem.astro";
+import type { DateParts } from "@/utilities/dates";
 import { COLLECTION_ITEM_LIST_ID } from "@/utilities/filter";
+import type { Tag } from "./Tags.astro";
+import type { MediaValueProps } from "@/env";
 
 const {
   items = [],
   showEvent = false,
   currentPage = 1,
   filteredLength = 1,
+  layoutType = null,
+  collectionSlug = "",
 } = Astro.props;
+
+export interface CollectionItem {
+  title: string;
+  description?: string;
+  date?: string | DateParts;
+  publishedAt?: string | DateParts;
+  tags?: Tag[];
+  media?: MediaValueProps;
+  link?: string;
+  linkText?: string;
+  itemType?: "list" | "grid";
+  collectionSlug?: string;
+}
+
 const PAGE_SIZE = import.meta.env.PAGE_SIZE ?? 10;
 const resultsRangeStart = (currentPage - 1) * PAGE_SIZE + 1;
 const resultsRangeEnd = Math.min(currentPage * PAGE_SIZE, filteredLength);
@@ -41,15 +60,34 @@ const resultsCountTextSr =
     }
   </p>
   <div id="active-filters" class="filter-pills"></div>
-  <div>
-    {
-      filteredLength > 0 && (
-        <ul class="usa-collection measure-6" id={COLLECTION_ITEM_LIST_ID}>
-          {items.map((n) => (
-            <CollectionItem {...n} showEvent={showEvent} />
-          ))}
-        </ul>
-      )
-    }
-  </div>
+  {
+    layoutType === "grid" ? (
+      <div>
+        {filteredLength > 0 && (
+          <div
+            class="grid-row grid-gap resource-cards-grid"
+            id={COLLECTION_ITEM_LIST_ID}
+          >
+            {items.map((n: CollectionItem) => (
+              <CollectionItem
+                {...n}
+                itemType={layoutType}
+                collectionSlug={collectionSlug}
+              />
+            ))}
+          </div>
+        )}
+      </div>
+    ) : (
+      <div>
+        {filteredLength > 0 && (
+          <ul class="usa-collection measure-6" id={COLLECTION_ITEM_LIST_ID}>
+            {items.map((n: CollectionItem) => (
+              <CollectionItem {...n} showEvent={showEvent} />
+            ))}
+          </ul>
+        )}
+      </div>
+    )
+  }
 </>

--- a/src/components/FiltersCollectionItemTemplate.astro
+++ b/src/components/FiltersCollectionItemTemplate.astro
@@ -6,17 +6,23 @@ interface Props {
   item: any;
   filtersSlugMetaData: FiltersSlugMetaDataModel;
   showEvent: boolean;
+  layoutType?: "grid" | "list";
 }
 
-const { item, filtersSlugMetaData, showEvent = false } = Astro.props;
+const {
+  item,
+  filtersSlugMetaData,
+  layoutType,
+  showEvent = false,
+} = Astro.props;
 ---
 
 {
   filtersSlugMetaData && (
     <template id={filtersSlugMetaData.collectionItemId}>
-      <div>
-        <CollectionItem {...item} showEvent={showEvent} />
-      </div>
+      <>
+        <CollectionItem {...item} itemType={layoutType} showEvent={showEvent} />
+      </>
     </template>
   )
 }

--- a/src/pages/[collectionSlug]/[slug].astro
+++ b/src/pages/[collectionSlug]/[slug].astro
@@ -249,5 +249,6 @@ const filtersSlugMetaData: FiltersSlugMetaDataModel = getFiltersSlugMetaData(
   item={item}
   showEvent={false}
   filtersSlugMetaData={filtersSlugMetaData}
+  layoutType={collectionConfig?.layoutType}
 />
 <PreviewReload />

--- a/src/pages/[collectionSlug]/index.astro
+++ b/src/pages/[collectionSlug]/index.astro
@@ -34,6 +34,7 @@ let totalPages = 1;
 let hasPaginationNav = false;
 let sorted = null;
 let relatedItems = null;
+let layoutType = null;
 
 if (!collectionConfig) {
   // Check if this is a regular page - if so, render it here since this route matched first
@@ -47,11 +48,11 @@ if (!collectionConfig) {
     fetchCollectionEntry,
   );
 } else {
+  layoutType = collectionConfig?.layoutType;
   // Fetch pages for this custom collection
   const collectionPagesData = await fetchCollectionEntries(collectionConfig.id);
 
   collectionPages = collectionPagesData?.docs || [];
-
   // Sort by publishedAt
   sorted = collectionPages.sort((a: any, b: any) => {
     return (
@@ -135,6 +136,8 @@ export const prerender = import.meta.env.PREVIEW_MODE ?? false;
           items={items}
           currentPage="1"
           filteredLength={sorted?.length}
+          layoutType={layoutType}
+          collectionSlug={collectionSlug}
         />
         {hasPaginationNav && (
           <PaginationNav

--- a/src/pages/[collectionSlug]/page/[page].astro
+++ b/src/pages/[collectionSlug]/page/[page].astro
@@ -27,6 +27,7 @@ if (!collectionConfig) {
 
 // Fetch pages for this custom collection
 const collectionPagesData = await fetchCollectionEntries(collectionConfig.id);
+const layoutType = collectionConfig?.layoutType;
 const collectionPages = collectionPagesData?.docs || [];
 
 // Sort by publishedAt
@@ -51,16 +52,14 @@ export async function getStaticPaths() {
     const data = await fetchCollection("collection-types");
     const configs = data?.docs || [];
 
-    const paths: any[] = [];
+    const pageSize = Number(PAGE_SIZE || 10);
+    const paths: { params: { collectionSlug: string; page: string } }[] = [];
 
     for (const config of configs) {
-      const pagesData = await fetchCollection(
-        `collection-entries?where[collectionType][id][equals]=${config.id}&limit=0`,
-      );
+      const entries = await fetchCollectionEntries(config.id);
 
-      const pages = pagesData?.docs || [];
-      const totalPages = pages.length;
-      const totalPagesCount = Math.ceil(totalPages / PAGE_SIZE);
+      const pages = entries?.docs || [];
+      const totalPagesCount = Math.max(1, Math.ceil(pages.length / pageSize));
 
       // Generate paths for each page
       for (let i = 1; i <= totalPagesCount; i++) {
@@ -104,6 +103,7 @@ const filteredPageConfig = {
     <CollectionItemList
       items={items}
       currentPage={currentPage}
+      layoutType={layoutType}
       filteredLength={sorted.length}
     />
     {


### PR DESCRIPTION
Closes: #211 

## Changes proposed in this pull request:

- Creates a Card layout display option for collections
- Includes filtering and pagination same as List layout
- Adds a small unit test to Card component view template.

## Screenshots

<img width="1495" height="880" alt="Screenshot 2026-04-15 at 3 41 17 PM (2)" src="https://github.com/user-attachments/assets/1d6cd308-b10e-429b-8ace-1816b63fa92d" />

<img width="1523" height="817" alt="Screenshot 2026-04-15 at 3 41 30 PM (2)" src="https://github.com/user-attachments/assets/a3916b35-8ae6-4fd9-a71f-6dfdefa2e5ff" />

<img width="671" height="658" alt="Screenshot 2026-04-15 at 3 42 04 PM (2)" src="https://github.com/user-attachments/assets/3d4833df-1353-46c8-843c-2c9d48c49dc6" />


## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

No considerations. Front end changes to collections view.
