### PR TITLE
fix: side nav collection type href value

### DIFF
--- a/src/components/PageWithSideNav.astro
+++ b/src/components/PageWithSideNav.astro
@@ -8,6 +8,10 @@ import {
   convertMenuToSideNav,
 } from "@/utilities/navigation";
 import Media from "./Media.astro";
+import {
+  buildMenuWithCollectionSlugs,
+  fetchCollectionEntry,
+} from "@/utilities/fetch";
 
 interface NavItem {
   id: string;
@@ -65,13 +69,17 @@ if (showSideNav && sideNavItems.length === 0) {
     if (sideNavResponse.ok) {
       const sideNavData = await sideNavResponse.json();
 
+      const [itemsWithSlugPath] = await Promise.all([
+        buildMenuWithCollectionSlugs(sideNavData.items, fetchCollectionEntry),
+      ]);
+
       // Check if page menu is enabled
       sideNavEnabled = sideNavData.enabled !== false;
       sideNavTitle = sideNavData.title || "Page Navigation";
 
       if (sideNavEnabled && sideNavData.items && sideNavData.items.length > 0) {
         // Convert page menu items to nav format
-        navItems = convertMenuToSideNav(sideNavData.items);
+        navItems = convertMenuToSideNav(itemsWithSlugPath);
       } else if (sideNavEnabled && sideNavData.fallbackToAllPages) {
         // Fallback to auto-generated navigation if enabled
         const response = await payloadFetch(

--- a/src/components/SideNav.astro
+++ b/src/components/SideNav.astro
@@ -51,7 +51,7 @@ const hasActiveChild = (item: NavItem): boolean => {
             {item.children && item.children.length > 0 ? (
               // Dropdown parent - not clickable but shows active state
               <span
-                className={`usa-sidenav__link ${hasActiveChildren ? "usa-current" : ""}`}
+                class={`usa-sidenav__link ${hasActiveChildren ? "usa-current" : ""}`}
               >
                 {item.label}
               </span>

--- a/src/pages/[collectionSlug]/[slug].astro
+++ b/src/pages/[collectionSlug]/[slug].astro
@@ -19,6 +19,7 @@ import { getFiltersSlugMetaData } from "@/utilities/filter";
 import type { FiltersSlugMetaDataModel } from "@/env";
 import FiltersCollectionItemTemplate from "@/components/FiltersCollectionItemTemplate.astro";
 import ContentBlocks from "@/components/ContentBlocks.astro";
+import PageWithSideNav from "@/components/PageWithSideNav.astro";
 
 export interface TagProps {
   title: string;
@@ -119,7 +120,12 @@ const filtersSlugMetaData: FiltersSlugMetaDataModel = getFiltersSlugMetaData(
   useBreadcrumbTitle={true}
   filtersSlugMetaData={filtersSlugMetaData}
 >
-  <PagesSection heading={data.title}>
+  <PageWithSideNav
+    heading={data.title}
+    showSideNav={true}
+    currentPath={`/${collectionSlug}/${pageSlug}`}
+    sideNavId={data.sideNavigation?.id}
+  >
     <article class="grid-container padding-top-0 usa-section">
       <div class="grid-row grid-gap grid-gap-6">
         {/* set colum width if related items are present */}
@@ -243,7 +249,7 @@ const filtersSlugMetaData: FiltersSlugMetaDataModel = getFiltersSlugMetaData(
       </div>
       <div class="flex-column margin-bottom-5"></div>
     </article>
-  </PagesSection>
+  </PageWithSideNav>
 </Layout>
 <FiltersCollectionItemTemplate
   item={item}

--- a/src/pages/[collectionSlug]/index.astro
+++ b/src/pages/[collectionSlug]/index.astro
@@ -95,7 +95,7 @@ export const prerender = import.meta.env.PREVIEW_MODE ?? false;
       <PageWithSideNav
         heading={page.title}
         showSideNav={true}
-        currentPath={`/${collectionSlug}`}
+        currentPath={`${page.slug}`}
         sideNavId={page.sideNavigation?.id}
       >
         <div class="grid-row grid-gap grid-gap-6">

--- a/src/pages/[slug].astro
+++ b/src/pages/[slug].astro
@@ -32,7 +32,7 @@ export const prerender = import.meta.env.PREVIEW_MODE ?? false;
   <PageWithSideNav
     heading={page.title}
     showSideNav={true}
-    currentPath={`/${page.slug}`}
+    currentPath={`${page.slug}`}
     sideNavId={page.sideNavigation?.id}
     heroImage={page.image}
     description={page.description}

--- a/src/utilities/navigation.test.ts
+++ b/src/utilities/navigation.test.ts
@@ -1,0 +1,147 @@
+import { describe, it, expect } from "vitest";
+import { convertMenuToSideNav } from "./navigation"; // <-- adjust import path
+// or: import { convertMenuToSideNav } from "@/utilities/navigation"; (if your vitest config resolves @)
+
+describe("convertMenuToSideNav", () => {
+  it("maps top-level blockTypes to expected hrefs", () => {
+    const menuData = [
+      {
+        id: "1",
+        label: "A Page Link",
+        blockType: "pageLink",
+        page: {
+          id: 33,
+          slug: "golden-harbor-2070",
+          title: "Golden Harbor 2070",
+        },
+        order: 2,
+      },
+      {
+        id: "2",
+        label: "An External Link",
+        blockType: "externalLink",
+        url: "https://gsa.gov",
+        order: 1,
+      },
+      {
+        id: "3",
+        label: "A Site Link",
+        blockType: "link",
+        url: "https://cloud.gov",
+        order: 3,
+      },
+      {
+        id: "4",
+        label: "A Collection Type",
+        blockType: "collectionTypeLink",
+        collectionType: { id: 3, title: "Blog Posts", slug: "blog-posts" },
+        order: 5,
+      },
+      {
+        id: "5",
+        label: "A Collection Entry",
+        blockType: "collectionEntryLink",
+        collectionEntry: {
+          id: 2,
+          slug: "daring-summit-9331",
+          title: "Daring Summit 9331",
+          collectionSlug: "articles",
+        },
+        order: 4,
+      },
+    ];
+
+    const result = convertMenuToSideNav(menuData);
+
+    // sorting by order happens at the end
+    expect(result.map((i) => i.id)).toEqual(["2", "1", "3", "5", "4"]);
+
+    // NOTE: this matches your current implementation:
+    // top-level pageLink does NOT start with "/"
+    expect(result.find((i) => i.id === "1")?.href).toBe("golden-harbor-2070");
+
+    expect(result.find((i) => i.id === "2")?.href).toBe("https://gsa.gov");
+    expect(result.find((i) => i.id === "3")?.href).toBe("https://cloud.gov");
+    expect(result.find((i) => i.id === "4")?.href).toBe("/blog-posts");
+    expect(result.find((i) => i.id === "5")?.href).toBe(
+      "/articles/daring-summit-9331",
+    );
+  });
+
+  it("maps subitems and sorts children by order", () => {
+    const menuData = [
+      {
+        id: "parent",
+        label: "Parent",
+        blockType: "collectionTypeLink",
+        collectionType: { slug: "resources" },
+        order: 1,
+        subitems: [
+          {
+            id: "c",
+            label: "Child External",
+            blockType: "externalLink",
+            url: "https://example.com",
+            order: 3,
+          },
+          {
+            id: "a",
+            label: "Child Page",
+            blockType: "pageLink",
+            page: { slug: "child-page" },
+            order: 1,
+          },
+          {
+            id: "b",
+            label: "Child CollectionLink",
+            blockType: "collectionLink",
+            page: "projects",
+            order: 2,
+          },
+        ],
+      },
+    ];
+
+    const result = convertMenuToSideNav(menuData);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].href).toBe("/resources");
+
+    // children are sorted by their order
+    const children = result[0].children ?? [];
+    expect(children.map((c) => c.id)).toEqual(["a", "b", "c"]);
+
+    // child mapping rules (match your current implementation)
+    expect(children[0].href).toBe("/child-page"); // pageLink child has leading "/"
+    expect(children[1].href).toBe("/projects"); // collectionLink child
+    expect(children[2].href).toBe("https://example.com"); // externalLink child
+  });
+
+  it("falls back safely when fields are missing", () => {
+    const menuData = [
+      { label: "No ID", blockType: "externalLink", url: "https://x.test" },
+      { id: "has-id", label: "Unknown type", blockType: "weirdType" },
+      {
+        id: "no-url",
+        label: "External missing url",
+        blockType: "externalLink",
+      },
+      { id: "no-page", label: "Page missing page", blockType: "pageLink" },
+    ];
+
+    const result = convertMenuToSideNav(menuData);
+
+    // Random IDs are generated for missing id; just assert shape
+    expect(result[0].id).toBeTypeOf("string");
+    expect(result[0].id.length).toBeGreaterThan(0);
+
+    // Unknown blockType returns default "#"
+    expect(result.find((i) => i.id === "has-id")?.href).toBe("#");
+
+    // Missing url returns ""
+    expect(result.find((i) => i.id === "no-url")?.href).toBe("");
+
+    // Missing page.slug returns "" (because `${""}`)
+    expect(result.find((i) => i.id === "no-page")?.href).toBe("");
+  });
+});

--- a/src/utilities/navigation.ts
+++ b/src/utilities/navigation.ts
@@ -99,11 +99,11 @@ export function createBreadcrumbs(
       const newPath = [...path, item];
 
       if (item.href === currentPath) {
-        breadcrumbs.push(...newPath);
+        breadcrumbs.push(...(newPath as NavItem[]));
         return true;
       }
 
-      if (item.children && findPath(item.children, newPath)) {
+      if (item.children && findPath(item.children, newPath as string[])) {
         return true;
       }
     }
@@ -123,12 +123,21 @@ export function convertMenuToSideNav(menuItems: any[]): NavItem[] {
       let href = "#";
 
       // Handle different menu item types
-      if (item.blockType === "pageLink" && item.page) {
-        href = `/${item.page.slug}`;
-      } else if (item.blockType === "collectionLink") {
-        href = `/${item.page}`;
-      } else if (item.blockType === "externalLink" && item.url) {
-        href = item.url;
+      switch (item.blockType) {
+        case "pageLink":
+          href = `${item.page?.slug || ""}`;
+          break;
+        case "externalLink":
+          href = item.url || "";
+          break;
+        case "collectionTypeLink":
+          href = `/${item.collectionType?.slug || ""}`;
+          break;
+        case "collectionEntryLink":
+          href = `/${item.collectionEntry?.collectionSlug}/${item.collectionEntry?.slug}`;
+          break;
+        case "link":
+          href = item.url || "";
       }
 
       return {


### PR DESCRIPTION
Closes: #213 
## Changes proposed in this pull request:

- Updates the data handling for side nav links in the navigation utility
- Adds testing for the navigation utility

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

No concerns
