### PR TITLE
fix: set entry content date for display

### DIFF
--- a/src/pages/[collectionSlug]/[slug].astro
+++ b/src/pages/[collectionSlug]/[slug].astro
@@ -144,40 +144,14 @@ const filtersSlugMetaData: FiltersSlugMetaDataModel = getFiltersSlugMetaData(
           <div class="maxw-72 margin-bottom-4">
             <p class="text-gray-50">
               {
-                item.date && (
-                  <p class="font-sans-sm text-italic" set:text={item.date} />
+                contentDate && (
+                  <p
+                    class="font-sans-sm text-italic"
+                    set:text={contentDate.full}
+                  />
                 )
               }
             </p>
-            {
-              /* possible deprecated feature */
-              contentDate && (
-                <div
-                  class="usa-summary-box maxw-tablet margin-bottom-2"
-                  role="region"
-                  aria-labelledby={`content-details-${data.slug}`}
-                >
-                  <div class="usa-summary-box__body">
-                    <h2
-                      class="usa-summary-box__heading"
-                      id={`content-details-${data.slug}`}
-                    >
-                      Details
-                    </h2>
-                    <div class="usa-summary-box__text">
-                      <ul class="usa-list">
-                        {contentDate && (
-                          <li>
-                            <b>Date:</b> {contentDate.full}
-                          </li>
-                        )}
-                      </ul>
-                    </div>
-                  </div>
-                </div>
-              )
-            }
-
             {
               /* main content entry body */
               data.content && (

--- a/src/styles/custom/global.scss
+++ b/src/styles/custom/global.scss
@@ -1609,11 +1609,6 @@ footer.usa-footer .container,
   font-size: 1.125rem;
 }
 
-.usa-summary-box__heading {
-  font-family: var(--font-sans); 
-  font-size: 1.375rem;
-}
-
 .news-body-block {
   margin-bottom: 1rem;
 }
@@ -1927,11 +1922,6 @@ footer.usa-footer .container,
 
 .related-links-sidebar .usa-collection__heading {
   font-size: 1.125rem;
-}
-
-.usa-summary-box__heading {
-  font-family: var(--font-sans);
-  font-size: 1.375rem;
 }
 
 .news-tags.content-tags .usa-tag {


### PR DESCRIPTION
Closes: #[2891](https://github.com/cloud-gov/private/issues/2891)
## Changes proposed in this pull request:

- Sets the display date to use the contentDate field rather than the CMS publish date
- Removes deprecated summary box element and css declarations

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

[Note the any security considerations here, or make note of why there are none]
