### PR TITLE
fix: use content date when available

### DIFF
--- a/src/components/CollectionItem.astro
+++ b/src/components/CollectionItem.astro
@@ -9,8 +9,8 @@ import type { MediaValueProps } from "@/env";
 export interface Props {
   title: string;
   description?: string;
-  date?: string | DateParts;
   publishedAt?: string | DateParts;
+  contentDate?: string | DateParts;
   tags?: Tag[];
   media?: MediaValueProps;
   link?: string;
@@ -23,7 +23,7 @@ export interface Props {
 const {
   title = "",
   description = "",
-  date = "",
+  contentDate = "",
   tags = [],
   media = null,
   link = "",
@@ -40,7 +40,10 @@ function normalizeDate(input?: string | DateParts | null): DateParts | null {
     : null;
 }
 
-const dateParts = date ? normalizeDate(date) : normalizeDate(publishedAt);
+const dateParts = contentDate
+  ? normalizeDate(contentDate)
+  : normalizeDate(publishedAt);
+const contentDateParts = contentDate ? normalizeDate(contentDate) : null;
 
 const hasTags = tags?.length > 0;
 const hasDescription = !!description?.trim();
@@ -104,7 +107,7 @@ const hasValidDate = !!(
           <ul class="usa-collection__meta" aria-label="More information">
             <li class="usa-collection__meta-item collection-item-date">
               <time datetime={dateParts.raw.toISOString()}>
-                {dateParts.full}
+                {contentDateParts ? contentDateParts.full : dateParts.full}
               </time>
             </li>
           </ul>

--- a/src/components/CollectionItemList.astro
+++ b/src/components/CollectionItemList.astro
@@ -17,7 +17,6 @@ const {
 export interface CollectionItem {
   title: string;
   description?: string;
-  date?: string | DateParts;
   publishedAt?: string | DateParts;
   tags?: Tag[];
   media?: MediaValueProps;

--- a/src/pages/[collectionSlug]/[slug].astro
+++ b/src/pages/[collectionSlug]/[slug].astro
@@ -6,7 +6,6 @@ import {
   fetchCollectionEntry,
 } from "@/utilities/fetch";
 import { tryParseDateParts } from "@/utilities/dates";
-import PagesSection from "@/components/PagesSection.astro";
 import Layout from "@/layouts/Layout.astro";
 import Tags from "@/components/Tags.astro";
 import Media from "@/components/Media.astro";

--- a/src/utilities/fetch/contentMapper.ts
+++ b/src/utilities/fetch/contentMapper.ts
@@ -18,6 +18,7 @@ type ContentData = {
   content?: string;
   excerpt?: string;
   publishedAt?: string;
+  contentDate?: string;
   slug?: string;
   tags?: CollectionTagProps[];
   [key: string]: any;
@@ -26,7 +27,6 @@ type ContentData = {
 type MapperConfig = {
   baseUrl: string;
   dateField?: string;
-  dateConversionFunction?: (any) => any;
 };
 
 function safeParse(input?: string | number | Date): DateParts | null {
@@ -50,14 +50,15 @@ export function filteredContentMapper(data, baseUrl, yearTag) {
 
 export function contentMapper(
   data: ContentData,
-  { baseUrl, dateField = "publishedAt", dateConversionFunction }: MapperConfig,
+  { baseUrl, dateField = "publishedAt" }: MapperConfig,
 ) {
   const endSrc = (data as any).endDate;
 
   return {
     title: data.title,
     content: data.content,
-    date: dateConversionFunction(data[dateField] || data.publishedAt || ""),
+    publishedAt: data.publishedAt,
+    contentDate: data.contentDate,
     startDate: safeParse(data.startDate || ""),
     endDate: safeParse(endSrc),
     description: data.description || "",
@@ -77,7 +78,6 @@ export function customCollectionEntryMapper(data: any, collectionSlug: string) {
   return contentMapper(data, {
     baseUrl: `/${collectionSlug}`,
     dateField: data.contentDate ? "contentDate" : "publishedAt",
-    dateConversionFunction: formatDate,
   });
 }
 


### PR DESCRIPTION
## Changes proposed in this pull request:

- On collections lists shows the contentDate value if present otherwise displays the publishAt date

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

[Note the any security considerations here, or make note of why there are none]
