### PR TITLE
Fix show subtitle in component entry hero

### DIFF
--- a/src/components/PageWithSideNav.astro
+++ b/src/components/PageWithSideNav.astro
@@ -112,7 +112,7 @@ if (showSideNav && sideNavItems.length === 0) {
                   {heroImage && (
                     <div class="grid-row grid-gap sidebar-layout page-hero">
                       <div class="sidebar-layout__sidebar">
-                        <div class="council-hero__logo-container">
+                        <div class="council-hero__logo-container bg-white">
                           <Media media={heroImage} />
                         </div>
                       </div>
@@ -124,7 +124,16 @@ if (showSideNav && sideNavItems.length === 0) {
                       </div>
                     </div>
                   )}
-                  {!heroImage && <h1 class="margin-bottom-2">{heading}</h1>}
+                  {!heroImage && description && (
+                    <>
+                      <p class="council-hero__brow">{description}</p>
+                      <h1 class="margin-bottom-2">{heading}</h1>
+                    </>
+                  )}
+
+                  {!heroImage && !description && (
+                    <h1 class="margin-bottom-2">{heading}</h1>
+                  )}
                 </div>
               )}
             </div>
@@ -154,7 +163,7 @@ if (showSideNav && sideNavItems.length === 0) {
                   {heroImage && (
                     <div class="grid-row grid-gap sidebar-layout page-hero">
                       <div class="sidebar-layout__sidebar">
-                        <div class="council-hero__logo-container">
+                        <div class="council-hero__logo-container bg-white">
                           <Media media={heroImage} />
                         </div>
                       </div>
@@ -166,7 +175,15 @@ if (showSideNav && sideNavItems.length === 0) {
                       </div>
                     </div>
                   )}
-                  {!heroImage && <h1 class="margin-bottom-2">{heading}</h1>}
+                  {!heroImage && description && (
+                    <>
+                      <p class="council-hero__brow">{description}</p>
+                      <h1 class="margin-bottom-2">{heading}</h1>
+                    </>
+                  )}
+                  {!heroImage && !description && (
+                    <h1 class="margin-bottom-2">{heading}</h1>
+                  )}
                 </div>
               )}
             </div>

--- a/src/components/PageWithSideNav.test.ts
+++ b/src/components/PageWithSideNav.test.ts
@@ -1,0 +1,203 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { experimental_AstroContainer as AstroContainer } from "astro/container";
+
+// --- Mocks for test runs ---
+const payloadFetchMock = vi.fn();
+const buildMenuWithCollectionSlugsMock = vi.fn();
+const convertMenuToSideNavMock = vi.fn();
+
+vi.mock("@/utilities/fetch/payload-fetch", () => ({
+  payloadFetch: (...args: any[]) => payloadFetchMock(...args),
+}));
+
+vi.mock("@/utilities/fetch", () => ({
+  buildMenuWithCollectionSlugs: (...args: any[]) =>
+    buildMenuWithCollectionSlugsMock(...args),
+  fetchCollectionEntry: vi.fn(),
+}));
+
+vi.mock("@/utilities/navigation", () => ({
+  convertMenuToSideNav: (...args: any[]) => convertMenuToSideNavMock(...args),
+  createNavFromPages: vi.fn(() => []),
+  organizeNavItems: vi.fn(() => []),
+}));
+
+type AstroRender = string | { html: string };
+
+const mockResponse = (jsonData: any, ok = true) => ({
+  ok,
+  json: async () => jsonData,
+});
+
+describe("PageWithSideNav", () => {
+  let container: Awaited<ReturnType<typeof AstroContainer.create>>;
+
+  // Import fresh each test to honor per-test mock implementations
+  const importComponent = async () => {
+    const mod = await import("./PageWithSideNav.astro");
+    return mod.default;
+  };
+
+  const renderHTML = async (
+    Component: any,
+    props: Record<string, any> = {},
+  ) => {
+    const res = (await container.renderToString(Component, {
+      props,
+    })) as AstroRender;
+    return typeof res === "string" ? res : res.html;
+  };
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    vi.resetModules();
+    container = await AstroContainer.create();
+
+    buildMenuWithCollectionSlugsMock.mockImplementation(
+      async (items: any[]) => items,
+    );
+    convertMenuToSideNavMock.mockImplementation((items: any[]) => items);
+
+    // Default: if fetch is called unexpectedly, fail loudly
+    payloadFetchMock.mockImplementation(() => {
+      throw new Error(
+        "payloadFetch was called but not configured in this test",
+      );
+    });
+  });
+
+  it("renders SideNav wrapper when showSideNav is true and sideNavItems are provided", async () => {
+    const Component = await importComponent();
+
+    const html = await renderHTML(Component, {
+      heading: "Heading",
+      description: "Desc",
+      currentPath: "/test",
+      showSideNav: true,
+      sideNavItems: [{ id: "1", label: "One", href: "/one" }],
+    });
+
+    expect(html).toMatch(/<aside[^>]*class="sidenav-container"[^>]*>/);
+    expect(html).toMatch(
+      /<aside[^>]*class="sidenav-container"[^>]*>[\s\S]*<\/aside>/,
+    );
+  });
+
+  it("renders hero image wrapper markup when heroImage prop is provided", async () => {
+    const Component = await importComponent();
+
+    const html = await renderHTML(Component, {
+      heading: "Heading",
+      description: "Desc",
+      currentPath: "/test",
+      showSideNav: false, // focus on hero area
+      heroImage: {
+        url: "/img.png",
+        filename: "img.png",
+        site: { bucket: "bucket" },
+      },
+    });
+
+    // This wrapper is only present in the heroImage branch in component markup
+    expect(html).toMatch(
+      /<div[^>]*class="council-hero__logo-container[^"]*"[^>]*>[\s\S]*<\/div>/,
+    );
+    expect(html).toContain("page-hero");
+  });
+
+  it("renders description even when heroImage is not present (description provided)", async () => {
+    const Component = await importComponent();
+
+    const html = await renderHTML(Component, {
+      heading: "Heading",
+      description: "This should show",
+      currentPath: "/test",
+      showSideNav: false,
+      heroImage: null,
+    });
+
+    // Allow for Astro's injected data-astro-* attributes
+    expect(html).toMatch(
+      /<p[^>]*class="council-hero__brow"[^>]*>\s*This should show\s*<\/p>/,
+    );
+  });
+
+  it("does not render hero image or description markup when neither is present", async () => {
+    const Component = await importComponent();
+
+    const html = await renderHTML(Component, {
+      heading: "Heading Only",
+      description: "",
+      currentPath: "/test",
+      showSideNav: false,
+      heroImage: null,
+    });
+
+    expect(html).not.toContain("council-hero__brow");
+    expect(html).not.toContain("page-hero");
+    expect(html).toMatch(/<h1[^>]*>\s*Heading Only\s*<\/h1>/);
+  });
+
+  it("does not render sidenav markup when showSideNav is false (even if items exist)", async () => {
+    const Component = await importComponent();
+
+    const html = await renderHTML(Component, {
+      heading: "Heading",
+      currentPath: "/test",
+      showSideNav: false,
+      sideNavItems: [{ id: "1", label: "One", href: "/one" }],
+    });
+
+    expect(html).not.toContain('<aside class="sidenav-container">');
+  });
+
+  it("fetches side nav config when showSideNav=true and sideNavItems empty, and renders sidenav when enabled+items exist", async () => {
+    const Component = await importComponent();
+
+    payloadFetchMock.mockImplementation(async (path: string) => {
+      if (path === "side-navigation/abc") {
+        return mockResponse({
+          enabled: true,
+          title: "Page Navigation",
+          items: [{ id: "1", label: "One", href: "/one" }],
+          fallbackToAllPages: false,
+        });
+      }
+      throw new Error(`Unexpected payloadFetch path: ${path}`);
+    });
+
+    const html = await renderHTML(Component, {
+      heading: "Heading",
+      currentPath: "/test",
+      showSideNav: true,
+      sideNavId: "abc",
+      sideNavItems: [], // triggers fetch path
+    });
+
+    expect(payloadFetchMock).toHaveBeenCalledWith("side-navigation/abc");
+    expect(html).toMatch(/<aside[^>]*class="sidenav-container"[^>]*>/);
+  });
+
+  it("does not render sidenav markup when fetched config disables it", async () => {
+    const Component = await importComponent();
+
+    payloadFetchMock.mockResolvedValue(
+      mockResponse({
+        enabled: false,
+        title: "Page Navigation",
+        items: [{ id: "1", label: "One", href: "/one" }],
+      }),
+    );
+
+    const html = await renderHTML(Component, {
+      heading: "Heading",
+      currentPath: "/test",
+      showSideNav: true,
+      sideNavItems: [], // triggers fetch (global)
+      sideNavId: null,
+    });
+
+    expect(payloadFetchMock).toHaveBeenCalledWith("globals/side-navigation");
+    expect(html).not.toContain('<aside class="sidenav-container">');
+  });
+});

--- a/src/pages/[collectionSlug]/[slug].astro
+++ b/src/pages/[collectionSlug]/[slug].astro
@@ -124,6 +124,7 @@ const filtersSlugMetaData: FiltersSlugMetaDataModel = getFiltersSlugMetaData(
     showSideNav={true}
     currentPath={`/${collectionSlug}/${pageSlug}`}
     sideNavId={data.sideNavigation?.id}
+    description={data.description}
   >
     <article class="grid-container padding-top-0 usa-section">
       <div class="grid-row grid-gap grid-gap-6">

--- a/src/pages/[collectionSlug]/index.astro
+++ b/src/pages/[collectionSlug]/index.astro
@@ -97,6 +97,8 @@ export const prerender = import.meta.env.PREVIEW_MODE ?? false;
         showSideNav={true}
         currentPath={`${page.slug}`}
         sideNavId={page.sideNavigation?.id}
+        heroImage={page.image}
+        description={page.description}
       >
         <div class="grid-row grid-gap grid-gap-6">
           <div


### PR DESCRIPTION
Closes #https://github.com/cloud-gov/private/issues/2892
## Changes proposed in this pull request:

- Fixes a bug that caused the description to display only if a heroImage was present
- Adds a test for the PageWithSideNav component

## Screenshots
<img width="964" height="601" alt="Screenshot 2026-04-22 at 3 25 21 PM" src="https://github.com/user-attachments/assets/5a01a9d0-dd01-4e97-b781-2eaec61a4bc5" />
<br />
<img width="877" height="444" alt="Screenshot 2026-04-22 at 4 04 59 PM" src="https://github.com/user-attachments/assets/c95cc09d-edab-4144-b6d7-dbfbb4afd60f" />
<br />
<img width="880" height="508" alt="Screenshot 2026-04-22 at 4 04 31 PM" src="https://github.com/user-attachments/assets/49b6e3c9-1cfe-4649-96e0-8d08b04952a6" />



## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

No
