### PR TITLE
feat: add resource-like link for collections

### DIFF
--- a/src/components/CollectionItem.astro
+++ b/src/components/CollectionItem.astro
@@ -4,7 +4,7 @@ import SectionHeader from "@/components/SectionHeader.astro";
 import Tags, { type Tag } from "@/components/Tags.astro";
 import Media from "@/components/Media.astro";
 import { parseDateParts, type DateParts } from "@/utilities/dates";
-import type { MediaValueProps } from "@/env";
+import type { CollectionExternalLink, MediaValueProps } from "@/env";
 
 export interface Props {
   title: string;
@@ -18,6 +18,7 @@ export interface Props {
   itemType?: "list" | "grid";
   collectionSlug?: string;
   showEvent?: boolean;
+  externalLink?: CollectionExternalLink;
 }
 
 const {
@@ -30,6 +31,7 @@ const {
   publishedAt = null,
   itemType = null,
   collectionSlug = null,
+  externalLink = null,
 } = Astro.props;
 
 function normalizeDate(input?: string | DateParts | null): DateParts | null {
@@ -47,6 +49,13 @@ const contentDateParts = contentDate ? normalizeDate(contentDate) : null;
 
 const hasTags = tags?.length > 0;
 const hasDescription = !!description?.trim();
+
+/* compute link text and href in case of an external link */
+const externalHref = externalLink?.url?.trim();
+const externalLabel = externalLink?.label?.trim();
+
+const resolvedHref = externalHref ?? link;
+const resolvedLabel = externalLabel ?? `View ${collectionSlug} item`;
 
 const hasValidDate = !!(
   dateParts &&
@@ -85,7 +94,7 @@ const hasValidDate = !!(
           </div>
           <div class="usa-card__footer">
             <span class="usa-link usa-link--external font-sans-sm">
-              <Link href={link}>View {collectionSlug} item</Link>
+              <Link href={resolvedHref}>{resolvedLabel}</Link>
             </span>
           </div>
         </div>

--- a/src/components/CollectionItemList.astro
+++ b/src/components/CollectionItemList.astro
@@ -3,7 +3,7 @@ import CollectionItem from "@/components/CollectionItem.astro";
 import type { DateParts } from "@/utilities/dates";
 import { COLLECTION_ITEM_LIST_ID } from "@/utilities/filter";
 import type { Tag } from "./Tags.astro";
-import type { MediaValueProps } from "@/env";
+import type { MediaValueProps, CollectionExternalLink } from "@/env";
 
 const {
   items = [],
@@ -24,6 +24,7 @@ export interface CollectionItem {
   linkText?: string;
   itemType?: "list" | "grid";
   collectionSlug?: string;
+  externalLink?: CollectionExternalLink;
 }
 
 const PAGE_SIZE = import.meta.env.PAGE_SIZE ?? 10;

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -437,6 +437,10 @@ const collectionEntries = defineCollection({
       contentDate: z.string().datetime().optional(),
       tags: z.array(cCustom.optional()).optional(),
       site: z.any(),
+      externalLink: z.object({
+        url: z.string(),
+        hyperlinkLabel: z.string(),
+      }),
       content: z.any().optional(), // richText
       reviewReady: z.boolean().optional(),
       showInPageNav: z.boolean().optional(),

--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -229,6 +229,11 @@ export interface AlertModel {
   alignment?: "left" | "center";
 }
 
+export interface CollectionExternalLink {
+  label?: string;
+  url?: string;
+}
+
 export interface IdentifierColorFamilies {
   identifier: string;
   identityDomain: string;

--- a/src/utilities/fetch/contentMapper.ts
+++ b/src/utilities/fetch/contentMapper.ts
@@ -35,7 +35,11 @@ function safeParse(input?: string | number | Date): DateParts | null {
   return Number.isNaN(parts.raw.getTime()) ? null : parts;
 }
 
-export function filteredContentMapper(data, baseUrl, yearTag) {
+export function filteredContentMapper(
+  data: any,
+  baseUrl: string,
+  yearTag: string,
+) {
   return {
     tags: (data.tags ?? []).map(
       (c): Tag => ({
@@ -66,6 +70,7 @@ export function contentMapper(
     imageAlt: data.image?.altText || data.title,
     link: `${baseUrl}/${data.slug}`,
     showInPageNav: data.showInPageNav ?? true,
+    externalLink: data.externalLink,
     ...filteredContentMapper(
       data,
       baseUrl,
@@ -101,11 +106,11 @@ export function alertsMapper(
   responseData: any,
   preRendered: boolean = false,
 ): AlertModel[] {
-  const getData = (a) => (preRendered ? a?.data : a);
+  const getData = (a: any) => (preRendered ? a?.data : a);
   return (
     responseData
-      ?.filter((a) => !!getData(a)?.isActive)
-      ?.map((a) => {
+      ?.filter((a: any) => !!getData(a)?.isActive)
+      ?.map((a: any) => {
         const data = getData(a);
         const result: AlertModel = {
           title: data.title,


### PR DESCRIPTION
Closes #https://github.com/cloud-gov/private/issues/2890
## Changes proposed in this pull request:

Depends on PR https://github.com/cloud-gov/pages-editor/pull/293
- Adds support for collectionItemLink to display in Card Grid view an optional link in favor of defaulting to the link to the content item itself.

## Considerations

Should the card title link to the content item especially when the bottom link now points to the optional collectionItemLink?

## Screenshots
Hover over normal link back to the content item
<img width="892" height="890" alt="Screenshot 2026-04-24 at 11 15 51 AM" src="https://github.com/user-attachments/assets/7bb965ea-0cec-414f-ad44-679044659112" />


Hover over "View resource" link added
<img width="880" height="826" alt="Screenshot 2026-04-24 at 11 15 19 AM" src="https://github.com/user-attachments/assets/a947f610-2234-4e23-a3e8-fb3ae590b8e2" />



## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

No concerns
