### PR TITLE
fix: add rich text to home page

### DIFF
--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -184,7 +184,6 @@ const homepage = defineCollection({
                 id: z.string().nullable().optional(),
                 blockName: z.string().nullable().optional(),
                 blockType: z.literal("richText"),
-                
               }),
             ]),
           )

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -159,6 +159,33 @@ const homepage = defineCollection({
                 blockName: z.string().nullable().optional(),
                 blockType: z.literal("textBlock"),
               }),
+              z.object({
+                content: z
+                  .object({
+                    root: z.object({
+                      type: z.string(),
+                      children: z.array(z.any()),
+                      direction: z.enum(["ltr", "rtl"]).nullable(),
+                      format: z.enum([
+                        "left",
+                        "start",
+                        "center",
+                        "right",
+                        "end",
+                        "justify",
+                        "",
+                      ]),
+                      indent: z.number(),
+                      version: z.number(),
+                    }),
+                  })
+                  .nullable()
+                  .optional(),
+                id: z.string().nullable().optional(),
+                blockName: z.string().nullable().optional(),
+                blockType: z.literal("richText"),
+                
+              }),
             ]),
           )
           .nullable()


### PR DESCRIPTION
## Changes proposed in this pull request:

-  Add rich text to site gantry home page, It was added on pages but not to gantry (https://github.com/cloud-gov/pages-editor/pull/294)


## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations
No security issues
