### PR TITLE
fix: add external link icon when external link is provided

### DIFF
--- a/src/components/Identifier.astro
+++ b/src/components/Identifier.astro
@@ -78,7 +78,7 @@ const cleanBaseUrl = baseUrl === "/" ? "" : baseUrl;
                 <li class={`usa-identifier__required-links-item`}>
                   <a
                     href={cleanBaseUrl + link.url}
-                    class={`usa-identifier__required-link usa-link text-${secondaryLinkColor}${link.externalLink && " usa-link--external"}`}
+                    class={`usa-identifier__required-link usa-link${secondaryLinkColor ? ` text-${secondaryLinkColor}` : ""}${link.externalLink ? " usa-link--external" : ""}`}
                   >
                     {link.text}
                   </a>

--- a/src/components/Identifier.test.ts
+++ b/src/components/Identifier.test.ts
@@ -93,12 +93,11 @@ describe("Identifier", () => {
     );
     expect(result).toContain('href="https://www.usa.gov/"');
     expect(result).toContain("Visit USA.gov");
-    
-    expect(result).toContain("usa-link usa-link--external")
-    
+
+    expect(result).toContain("usa-link usa-link--external");
   });
 
-  it("does not render external link properties when no external link is provided", async()=>{
+  it("does not render external link properties when no external link is provided", async () => {
     const siteDomain = "Domain.gov";
     const container = await AstroContainer.create();
     const result = await container.renderToString(Identifier, {
@@ -128,13 +127,9 @@ describe("Identifier", () => {
       },
     });
 
-     
     expect(result).toContain(agencyText);
     expect(result).toContain(siteDomain);
     expect(result).toContain('href="https://domain.gov"');
     expect(result).to.not.contain("usa-link usa-link--external");
-   
-
-  })
+  });
 });
-

--- a/src/components/Identifier.test.ts
+++ b/src/components/Identifier.test.ts
@@ -93,5 +93,48 @@ describe("Identifier", () => {
     );
     expect(result).toContain('href="https://www.usa.gov/"');
     expect(result).toContain("Visit USA.gov");
+    
+    expect(result).toContain("usa-link usa-link--external")
+    
   });
+
+  it("does not render external link properties when no external link is provided", async()=>{
+    const siteDomain = "Domain.gov";
+    const container = await AstroContainer.create();
+    const result = await container.renderToString(Identifier, {
+      props: {
+        identifier: {
+          siteDomain,
+          content,
+          links: [
+            {
+              text: "About This Agency",
+              url: "https://www.agency.gov/about-us",
+              externalLink: false,
+            },
+            {
+              text: "Agency Statement",
+              url: "https://www.agency.gov/statement",
+              externalLink: false,
+            },
+          ],
+          logos: [
+            {
+              media: { altText: "Alt Text" },
+              url: "https://domain.gov",
+            },
+          ],
+        },
+      },
+    });
+
+     
+    expect(result).toContain(agencyText);
+    expect(result).toContain(siteDomain);
+    expect(result).toContain('href="https://domain.gov"');
+    expect(result).to.not.contain("usa-link usa-link--external");
+   
+
+  })
 });
+

--- a/src/components/PreFooterBig.astro
+++ b/src/components/PreFooterBig.astro
@@ -80,7 +80,7 @@ const bkgColor = colors?.bkgColorLightest;
                             {topic.links.map((link, index) => (
                               <li class="usa-footer__secondary-content usa-footer__secondary-link">
                                 <Link
-                                  className="usa-footer__secondary-link"
+                                  className={`usa-footer__secondary-link${link.externalLink ? " usa-link--external" : ""}`}
                                   href={link.url}
                                 >
                                   {link.text}

--- a/src/components/PreFooterBig.test.ts
+++ b/src/components/PreFooterBig.test.ts
@@ -6,7 +6,7 @@ import {
   type PreFooterBigModel,
   CONNECT_SECTION_BOTTOM,
 } from "@/env";
-import { getCouncilsLinkGroups } from "@/components/PreFooterBig.testData";
+import { getCouncilsExternalLinkGroups, getCouncilsLinkGroups } from "@/components/PreFooterBig.testData";
 import { getConnectSectionFull } from "@/components/ConnectSection.testData";
 
 describe("PreFooterBig", () => {
@@ -36,6 +36,8 @@ describe("PreFooterBig", () => {
     expect(result).toContain(
       '<nav class="usa-footer__nav" aria-label="Pre-footer contact center and social links"',
     );
+
+    expect(result).not.to.contain("usa-link--external")
   });
 
   it("renders only Connect Section if no LinkGroups", async () => {
@@ -118,4 +120,26 @@ describe("PreFooterBig", () => {
       '<nav class="usa-footer__nav" aria-label="Pre-footer contact center and social links"',
     );
   });
+
+  it("render external link clase if external link is provided", async()=>{
+    const preFooterBig: PreFooterBigModel = {
+      linkGroups: getCouncilsExternalLinkGroups(),
+      connectSection: getConnectSectionFull(),
+      configuration: {
+        connectSectionLocation: CONNECT_SECTION_BOTTOM,
+        columnsInLinkGroup: LINK_GROUP_COLUMNS_DEFAULT,
+      },
+    };
+
+    const result = await container.renderToString(PreFooterBig, {
+      props: { preFooter: preFooterBig },
+    });
+    expect(result).toContain(
+      '<nav class="usa-footer__nav" aria-label="Pre-footer links"',
+    );
+    expect(result).toContain(
+      '<nav class="usa-footer__nav" aria-label="Pre-footer contact center and social links"',
+    );
+    expect(result).toContain("usa-link--external")
+  })
 });

--- a/src/components/PreFooterBig.test.ts
+++ b/src/components/PreFooterBig.test.ts
@@ -6,7 +6,10 @@ import {
   type PreFooterBigModel,
   CONNECT_SECTION_BOTTOM,
 } from "@/env";
-import { getCouncilsExternalLinkGroups, getCouncilsLinkGroups } from "@/components/PreFooterBig.testData";
+import {
+  getCouncilsExternalLinkGroups,
+  getCouncilsLinkGroups,
+} from "@/components/PreFooterBig.testData";
 import { getConnectSectionFull } from "@/components/ConnectSection.testData";
 
 describe("PreFooterBig", () => {
@@ -37,7 +40,7 @@ describe("PreFooterBig", () => {
       '<nav class="usa-footer__nav" aria-label="Pre-footer contact center and social links"',
     );
 
-    expect(result).not.to.contain("usa-link--external")
+    expect(result).not.to.contain("usa-link--external");
   });
 
   it("renders only Connect Section if no LinkGroups", async () => {
@@ -121,7 +124,7 @@ describe("PreFooterBig", () => {
     );
   });
 
-  it("render external link clase if external link is provided", async()=>{
+  it("render external link clase if external link is provided", async () => {
     const preFooterBig: PreFooterBigModel = {
       linkGroups: getCouncilsExternalLinkGroups(),
       connectSection: getConnectSectionFull(),
@@ -140,6 +143,6 @@ describe("PreFooterBig", () => {
     expect(result).toContain(
       '<nav class="usa-footer__nav" aria-label="Pre-footer contact center and social links"',
     );
-    expect(result).toContain("usa-link--external")
-  })
+    expect(result).toContain("usa-link--external");
+  });
 });

--- a/src/components/PreFooterBig.testData.ts
+++ b/src/components/PreFooterBig.testData.ts
@@ -437,7 +437,7 @@ export function getCouncilsExternalLinkGroups(): LinkGroup[] {
         {
           text: "Chief Information Officers Council",
           url: "#url3",
-        }
+        },
       ],
     },
   ];

--- a/src/components/PreFooterBig.testData.ts
+++ b/src/components/PreFooterBig.testData.ts
@@ -419,6 +419,29 @@ function getThreeLongLinkGroups(): LinkGroup[] {
   ];
 }
 
+export function getCouncilsExternalLinkGroups(): LinkGroup[] {
+  return [
+    {
+      name: "Federal Executive Councils",
+      links: [
+        {
+          text: "Chief Acquisition Officers Council",
+          url: "#url1",
+          externalLink: true,
+        },
+        {
+          text: "Chief Data Officers Council",
+          url: "#url2",
+          externalLink: true,
+        },
+        {
+          text: "Chief Information Officers Council",
+          url: "#url3",
+        }
+      ],
+    },
+  ];
+}
 export function getPreFooterBig(): PreFooterBigModel {
   const preFooterBigTest: PreFooterBigModel = {
     linkGroups: getLinkGroups(6), // 1 - 13

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -464,8 +464,8 @@ const collectionEntries = defineCollection({
       tags: z.array(cCustom.optional()).optional(),
       site: z.any(),
       externalLink: z.object({
-        url: z.string(),
-        hyperlinkLabel: z.string(),
+        url: z.string().optional().nullable(),
+        label: z.string().optional().nullable(),
       }),
       content: z.any().optional(), // richText
       reviewReady: z.boolean().optional(),

--- a/src/utilities/fetch/contentMapper.ts
+++ b/src/utilities/fetch/contentMapper.ts
@@ -151,7 +151,7 @@ export function linkMapper(link): LinkModel {
       result = {
         text: link?.label,
         url: link?.url,
-        externalLink: true,
+        externalLink: false,
       };
       break;
     case "slimExternalLink":


### PR DESCRIPTION
## Changes proposed in this pull request:

-  change "link" type to internal since this when using link type on link list only point to internal site
- corrected styling to ensure the external link icon is consistently displayed for all external links.
- Resolved a rendering issue where the nullish coalescing operator (??) could introduce 'false' or 'undefined' as class names. This was fixed by refactoring to a ternary operator, ensuring cleaner class attribute generation.


## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations
None
