### PR TITLE
fix: match collection schema

### DIFF
--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -200,7 +200,7 @@ const homepage = defineCollection({
 // Menu types to satisfy dropdown
 const BaseBlock = z.object({
   id: z.string(),
-  label: z.string(),
+  label: z.string().nullable().optional(),
   blockName: z.string().nullable().optional(),
 });
 


### PR DESCRIPTION
## Changes proposed in this pull request:

- My local building is failing because the `block_name `is optional.  Creating this PR to fix it because since it's optional on the `payload-types` and not tagged as optional in `content.config` it fails when no data is provided to `block_name`


## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations
None
