### PR TITLE
Add external link icon menu

### DIFF
--- a/src/components/Menu.astro
+++ b/src/components/Menu.astro
@@ -56,7 +56,7 @@ const { title, items = [], searchAccessKey, searchAffiliate } = Astro.props;
                     {item.links?.map((subitem) => {
                       let subHref = "#";
                       let isExternal = false;
-                      
+
                       if (subitem.blockType === "pageLink") {
                         subHref = `/${subitem.page.slug}`;
                       } else if (subitem.blockType === "link") {
@@ -76,7 +76,7 @@ const { title, items = [], searchAccessKey, searchAffiliate } = Astro.props;
                       return (
                         <li class="usa-nav__submenu-item">
                           <Link
-                            className={`usa-nav__link${isSubActive ? " usa-current" : ""}${isExternal? " usa-link--external " : ""}`}
+                            className={`usa-nav__link${isSubActive ? " usa-current" : ""}${isExternal ? " usa-link--external " : ""}`}
                             href={subHref}
                             aria-current={isSubActive ? "page" : undefined}
                           >
@@ -123,7 +123,7 @@ const { title, items = [], searchAccessKey, searchAffiliate } = Astro.props;
             return (
               <li class="usa-nav__primary-item">
                 <Link
-                  className={`usa-nav__link${isActive ? " usa-current" : ""}${isExternal? " usa-link--external" : ""}`}
+                  className={`usa-nav__link${isActive ? " usa-current" : ""}${isExternal ? " usa-link--external" : ""}`}
                   href={href}
                   aria-current={isActive ? "page" : undefined}
                 >

--- a/src/components/Menu.astro
+++ b/src/components/Menu.astro
@@ -55,19 +55,20 @@ const { title, items = [], searchAccessKey, searchAffiliate } = Astro.props;
                   >
                     {item.links?.map((subitem) => {
                       let subHref = "#";
-
+                      let isExternal = false;
+                      
                       if (subitem.blockType === "pageLink") {
                         subHref = `/${subitem.page.slug}`;
                       } else if (subitem.blockType === "link") {
                         subHref = `${subitem.url}`;
                       } else if (subitem.blockType === "externalLink") {
+                        isExternal = true;
                         subHref = `${subitem.url}`;
                       } else if (subitem.blockType === "collectionEntryLink") {
                         subHref = `/${subitem.collectionEntry?.collectionSlug}/${subitem.collectionEntry?.slug || ""}`;
                       } else if (subitem.blockType === "collectionTypeLink") {
                         subHref = `/${subitem.collectionType?.slug || ""}`;
                       }
-
                       const isSubActive =
                         currentPath === subHref ||
                         currentPath.startsWith(subHref + "/");
@@ -75,7 +76,7 @@ const { title, items = [], searchAccessKey, searchAffiliate } = Astro.props;
                       return (
                         <li class="usa-nav__submenu-item">
                           <Link
-                            className={`usa-nav__link${isSubActive ? " usa-current" : ""}`}
+                            className={`usa-nav__link${isSubActive ? " usa-current" : ""}${isExternal? " usa-link--external " : ""}`}
                             href={subHref}
                             aria-current={isSubActive ? "page" : undefined}
                           >
@@ -91,11 +92,13 @@ const { title, items = [], searchAccessKey, searchAffiliate } = Astro.props;
 
             let href = "#";
             let label = "";
+            let isExternal = false;
 
             if (item.blockType === "navItem") {
               href = `/${item.page.slug}`;
               label = item.label;
             } else if (item.blockType === "externalLink") {
+              isExternal = true;
               href = item.url;
               label = item.label;
             } else if (item.blockType === "link") {
@@ -120,7 +123,7 @@ const { title, items = [], searchAccessKey, searchAffiliate } = Astro.props;
             return (
               <li class="usa-nav__primary-item">
                 <Link
-                  className={`usa-nav__link${isActive ? " usa-current" : ""}`}
+                  className={`usa-nav__link${isActive ? " usa-current" : ""}${isExternal? " usa-link--external" : ""}`}
                   href={href}
                   aria-current={isActive ? "page" : undefined}
                 >

--- a/src/styles/custom/global.scss
+++ b/src/styles/custom/global.scss
@@ -808,6 +808,16 @@ main.home + .usa-footer:before{
 }
 
 .usa-header--basic {
+
+  .usa-link--external.usa-nav__link:hover::after {
+      position: inherit;
+      left: unset;
+      right: unset;
+      bottom: unset;
+      display: inline;
+      background-color: var(--color-white); 
+  }
+
   max-width: var(--max-width);
   width: 100%;
   margin-left: auto;
@@ -819,6 +829,14 @@ main.home + .usa-footer:before{
 
   @media (max-width: $breakpoint-desktop) {
     padding: 0;
+      .usa-link--external.usa-nav__link:hover::after {
+      position: inherit;
+      left: unset;
+      right: unset;
+      bottom: unset;
+      display: inline;
+      background-color: var(--primary-color); 
+  }
   }
 
   .usa-nav-container {


### PR DESCRIPTION
## Changes proposed in this pull request:

- Add external link icon to the menu when is an external link and fix external link icon class it wasn't getting displayed properly. Thanks @sknep for the scss work!

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations
- None