### PR TITLE
feat: add dropdown for user to select amount cards per row

### DIFF
--- a/src/components/CardGrid.astro
+++ b/src/components/CardGrid.astro
@@ -13,8 +13,7 @@ export interface Props {
   }>;
 }
 const { title, cards, amountCards } = Astro.props;
-const cardClass = `grid-col-${(12/Number(amountCards))-1}`;
-
+const cardClass = `grid-col-${12 / Number(amountCards) - 1}`;
 ---
 
 <section class="usa-section card-grid">
@@ -81,8 +80,6 @@ const cardClass = `grid-col-${(12/Number(amountCards))-1}`;
       flex: 0 0 100%;
     }
   }
-
-
 
   .usa-card__container {
     display: flex;

--- a/src/components/CardGrid.astro
+++ b/src/components/CardGrid.astro
@@ -13,6 +13,8 @@ export interface Props {
   }>;
 }
 const { title, cards, amountCards } = Astro.props;
+const cardClass = `grid-col-${(12/Number(amountCards))-1}`;
+
 ---
 
 <section class="usa-section card-grid">
@@ -22,7 +24,7 @@ const { title, cards, amountCards } = Astro.props;
     <div class="grid-row grid-gap">
       {
         cards?.map((card) => (
-          <div class="grid-col-6">
+          <div class={cardClass}>
             <div class="usa-card card-grid-item">
               <div class="usa-card__container">
                 {card.image && (
@@ -80,11 +82,7 @@ const { title, cards, amountCards } = Astro.props;
     }
   }
 
-  .card-grid-item {
-    display: flex;
-    flex-direction: column;
-    height: 100%;
-  }
+
 
   .usa-card__container {
     display: flex;

--- a/src/components/CardGrid.astro
+++ b/src/components/CardGrid.astro
@@ -3,6 +3,7 @@ import { getMediaUrl } from "@/utilities/media";
 
 export interface Props {
   title?: string;
+  amountCards?: number;
   cards: Array<{
     title: string;
     description: string;
@@ -11,8 +12,7 @@ export interface Props {
     ctaURL?: string;
   }>;
 }
-
-const { title, cards } = Astro.props;
+const { title, cards, amountCards } = Astro.props;
 ---
 
 <section class="usa-section card-grid">
@@ -22,7 +22,10 @@ const { title, cards } = Astro.props;
     <div class="grid-row grid-gap">
       {
         cards?.map((card) => (
-          <div class="tablet:grid-col-4">
+          <div
+            class="tablet:grid-col-6"
+            style={`flex: 0 0 calc((100% - 4rem) /${amountCards || 3} );`}
+          >
             <div class="usa-card card-grid-item">
               <div class="usa-card__container">
                 {card.image && (

--- a/src/components/CardGrid.astro
+++ b/src/components/CardGrid.astro
@@ -23,9 +23,7 @@ const { title, cards, amountCards } = Astro.props;
       {
         cards?.map((card) => (
           <div
-            class="tablet:grid-col-6"
-            style={`flex: 0 0 calc((100% - 4rem) /${Number(amountCards) || 3} );`}
-          >
+            class="grid-col-6">
             <div class="usa-card card-grid-item">
               <div class="usa-card__container">
                 {card.image && (

--- a/src/components/CardGrid.astro
+++ b/src/components/CardGrid.astro
@@ -22,8 +22,7 @@ const { title, cards, amountCards } = Astro.props;
     <div class="grid-row grid-gap">
       {
         cards?.map((card) => (
-          <div
-            class="grid-col-6">
+          <div class="grid-col-6">
             <div class="usa-card card-grid-item">
               <div class="usa-card__container">
                 {card.image && (

--- a/src/components/CardGrid.astro
+++ b/src/components/CardGrid.astro
@@ -3,7 +3,7 @@ import { getMediaUrl } from "@/utilities/media";
 
 export interface Props {
   title?: string;
-  amountCards?: number;
+  amountCards?: string;
   cards: Array<{
     title: string;
     description: string;
@@ -24,7 +24,7 @@ const { title, cards, amountCards } = Astro.props;
         cards?.map((card) => (
           <div
             class="tablet:grid-col-6"
-            style={`flex: 0 0 calc((100% - 4rem) /${amountCards || 3} );`}
+            style={`flex: 0 0 calc((100% - 4rem) /${Number(amountCards) || 3} );`}
           >
             <div class="usa-card card-grid-item">
               <div class="usa-card__container">

--- a/src/components/CardGrid.astro
+++ b/src/components/CardGrid.astro
@@ -3,6 +3,7 @@ import { getMediaUrl } from "@/utilities/media";
 
 export interface Props {
   title?: string;
+  amountCards?: string;
   cards: Array<{
     title: string;
     description: string;
@@ -11,8 +12,8 @@ export interface Props {
     ctaURL?: string;
   }>;
 }
-
-const { title, cards } = Astro.props;
+const { title, cards, amountCards } = Astro.props;
+const cardClass = `grid-col-${12 / Number(amountCards)}`;
 ---
 
 <section class="usa-section card-grid">
@@ -22,7 +23,7 @@ const { title, cards } = Astro.props;
     <div class="grid-row grid-gap">
       {
         cards?.map((card) => (
-          <div class="tablet:grid-col-4">
+          <div class={cardClass}>
             <div class="usa-card card-grid-item">
               <div class="usa-card__container">
                 {card.image && (
@@ -67,23 +68,12 @@ const { title, cards } = Astro.props;
   .grid-row {
     display: flex;
     flex-wrap: wrap;
-    gap: 1.5rem;
-  }
-
-  .grid-row > div {
-    padding: 0 !important;
   }
 
   @media (max-width: 768px) {
     .grid-row > div {
       flex: 0 0 100%;
     }
-  }
-
-  .card-grid-item {
-    display: flex;
-    flex-direction: column;
-    height: 100%;
   }
 
   .usa-card__container {

--- a/src/components/ContentBlocks.astro
+++ b/src/components/ContentBlocks.astro
@@ -18,6 +18,7 @@ type CardGridProps = {
     ctaText: string;
     ctaURL: string;
   }[];
+  amoundCard: number;
   title: string;
 };
 
@@ -74,6 +75,7 @@ const { contentBlocks = [] } = Astro.props;
           return (
             <CardGrid
               title={block.title}
+              amountCards={block.amountCards}
               cards={
                 block.cards?.map((card: any) => ({
                   title: card.title,

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -109,6 +109,7 @@ const homepage = defineCollection({
               z.object({
                 title: z.string().nullable().optional(),
                 description: z.string().nullable().optional(),
+                amountCards: z.number().nullable().optional(),
                 cards: z
                   .array(
                     z.object({

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -109,6 +109,7 @@ const homepage = defineCollection({
               z.object({
                 title: z.string().nullable().optional(),
                 description: z.string().nullable().optional(),
+                amountCards: z.string().nullable().optional(),
                 cards: z
                   .array(
                     z.object({

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -109,7 +109,7 @@ const homepage = defineCollection({
               z.object({
                 title: z.string().nullable().optional(),
                 description: z.string().nullable().optional(),
-                amountCards: z.number().nullable().optional(),
+                amountCards: z.string().nullable().optional(),
                 cards: z
                   .array(
                     z.object({

--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -75,6 +75,7 @@ export interface HomePage {
               | {
                   title: string;
                   description?: string | null;
+                  amountCards?: string | null;
                   image?: (number | null) | MediaValueProps;
                   link?: {
                     url?: string | null;

--- a/src/styles/custom/global.scss
+++ b/src/styles/custom/global.scss
@@ -556,9 +556,6 @@ footer.usa-footer .footer-grid-container,
   padding-bottom: 2rem;
   .grid-row {
     gap: 2rem;
-    & > div {
-      flex: 0 0 calc((100% - 4rem) / 3);
-    }
     @media (max-width: ($breakpoint-tablet - 0.0625rem)) {
       & > div {
       flex: none;

--- a/src/styles/custom/global.scss
+++ b/src/styles/custom/global.scss
@@ -555,10 +555,6 @@ footer.usa-footer .footer-grid-container,
   padding-top: 2rem;
   padding-bottom: 2rem;
   .grid-row {
-    gap: 2rem;
-    & > div {
-      flex: 0 0 calc((100% - 4rem) / 3);
-    }
     @media (max-width: ($breakpoint-tablet - 0.0625rem)) {
       & > div {
       flex: none;
@@ -580,9 +576,7 @@ footer.usa-footer .footer-grid-container,
         color: var(--primary-color);
       }
     }
-    &:last-child {
-      margin-bottom: 0;
-    }
+
     .usa-card__container {
       border-radius: 0;
       .usa-card__heading {


### PR DESCRIPTION
## Changes proposed in this pull request:

- Add dropdown for user to select the amount of cards they want to display per row where 3 is the default option
- Issue: https://github.com/cloud-gov/private/issues/2900

<img width="1148" height="642" alt="Screenshot 2026-05-05 at 10 59 27 AM" src="https://github.com/user-attachments/assets/8fc24650-ba35-4904-b3a3-b86d389cc0ea" />

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations
None
